### PR TITLE
fix: SVG image loss and text overflow

### DIFF
--- a/backend/generator/svg_critic.py
+++ b/backend/generator/svg_critic.py
@@ -142,6 +142,9 @@ class CriticConfig:
     # How much a text box may stick out of the canvas before flagging.
     out_of_bounds_slack: float = 2.0
 
+    # Minimum distance from text to canvas edge (safety margin).
+    min_edge_margin: float = 30.0
+
     # Allowed color-palette hex values (lowercased, without '#').
     # None = don't check.
     allowed_palette: set[str] | None = None
@@ -388,6 +391,42 @@ def check_svg(svg_content: str, config: CriticConfig | None = None) -> CriticRep
                 )
             )
 
+    # 2b. Image href validation.
+    for el in ordered_elements:
+        if _strip_ns(el.tag) != "image":
+            continue
+        href = (
+            el.get("{http://www.w3.org/1999/xlink}href")
+            or el.get("href", "")
+        )
+        if not href:
+            violations.append(
+                Violation(
+                    rule="image_missing_href",
+                    severity="error",
+                    detail=(
+                        "`<image>` element has no `href` attribute. "
+                        "Add a valid image source or remove the element."
+                    ),
+                    element=_element_identifier(el),
+                )
+            )
+        elif href.startswith("#"):
+            # Internal SVG reference (e.g. #checkIcon) — not supported by PPTX converter.
+            violations.append(
+                Violation(
+                    rule="image_internal_ref",
+                    severity="error",
+                    detail=(
+                        f"`<image href=\"{href}\">` uses an internal SVG reference "
+                        "which is not supported by the PPTX converter. "
+                        "Use `<use data-icon=\"...\"/>` for icons or embed the image "
+                        "as a data URI."
+                    ),
+                    element=_element_identifier(el),
+                )
+            )
+
     # 3. Font-size + text bbox checks.
     text_boxes: list[tuple[int, ET.Element, tuple[float, float, float, float]]] = []
     for el in ordered_elements:
@@ -428,6 +467,22 @@ def check_svg(svg_content: str, config: CriticConfig | None = None) -> CriticRep
                         detail=(
                             f"Text extends outside canvas ({cw:.0f}x{ch:.0f}). "
                             f"Estimated bbox ({x:.0f},{y:.0f},{w:.0f},{h:.0f})."
+                        ),
+                        element=_element_identifier(el),
+                        bbox=bbox,
+                    )
+                )
+
+            # Edge margin check: text too close to canvas edges.
+            margin = cfg.min_edge_margin
+            if x < margin or y < margin or x + w > cw - margin or y + h > ch - margin:
+                violations.append(
+                    Violation(
+                        rule="text_too_close_to_edge",
+                        severity="warning",
+                        detail=(
+                            f"Text is too close to the canvas edge (min margin {margin:.0f}px). "
+                            f"Move it inward to avoid clipping in the exported PPTX."
                         ),
                         element=_element_identifier(el),
                         bbox=bbox,

--- a/backend/generator/svg_to_pptx/elements.py
+++ b/backend/generator/svg_to_pptx/elements.py
@@ -326,6 +326,10 @@ def convert_image(elem: Any, ctx: ConvertContext) -> str:
         if not img_path.exists():
             img_path = (ctx.svg_dir.parent / href).resolve()
         if not img_path.exists():
+            import logging
+            logging.getLogger(__name__).warning(
+                "Image href %r not found, skipping element", href
+            )
             return ""
         img_data = img_path.read_bytes()
         ext = img_path.suffix.lstrip(".").lower()
@@ -457,7 +461,7 @@ def _build_text_shape(x: float, y: float, runs: list[dict], ctx: ConvertContext,
     max_font_size = max((run["font_size"] for run in runs), default=16)
     text_w = estimate_text_width(total_text, max_font_size, any(run["bold"] for run in runs))
     text_h = max_font_size * 1.35
-    padded_w = max(text_w * 1.45 + max_font_size, 24)
+    padded_w = max(text_w * 1.6 + max_font_size, 24)
 
     algn_map = {"start": "l", "middle": "ctr", "end": "r"}
     algn = algn_map.get(anchor, "l")

--- a/backend/generator/svg_to_pptx/utils.py
+++ b/backend/generator/svg_to_pptx/utils.py
@@ -226,9 +226,9 @@ def estimate_text_width(text: str, font_size: float, bold: bool = False) -> floa
         if is_cjk_char(ch):
             width += font_size
         elif ch == " ":
-            width += font_size * 0.3
+            width += font_size * 0.35
         else:
-            width += font_size * 0.55
+            width += font_size * 0.62
     if bold:
         width *= 1.05
     return width

--- a/backend/orchestrator/prompts/executor.md
+++ b/backend/orchestrator/prompts/executor.md
@@ -47,8 +47,8 @@ One complete SVG file per page with proper viewBox.
 3. Use proper text sizing: titles large, body readable, captions small
 4. Include decorative elements sparingly (dividers, subtle backgrounds)
 5. Data visualizations: use SVG shapes directly (rect bars, circle pies, path lines)
-6. Images: reference with `<image href="path" x="" y="" width="" height=""/>`
-7. Maintain consistent margins and spacing across all pages
+6. Images: reference with `<image href="path" x="" y="" width="" height=""/>`. The `href` MUST point to a real file path that exists (e.g. `../sources/images/fig_001_p1.png`). Do NOT invent filenames. If no real image is available, use native SVG shapes/charts/icons instead.
+7. Maintain consistent margins and spacing across all pages. Keep all text at least 40px away from the canvas edges (0 and 1280 horizontally, 0 and 720 vertically) to avoid clipping in the exported PPTX.
 8. For a single visual line of copy, use exactly one `<text>` element. Do not place multiple sibling `<text>` elements at the same or nearly the same x/y position to fake inline styling.
 9. Use inline `<tspan>` only for style emphasis within one line. Do not simulate subscripts, footnotes, or formulas by adding a second `<text>` node that starts at the same x position.
 10. Never use HTML `<span>` inside SVG. Inline emphasis must be SVG `<tspan>`, otherwise browser preview can leak the span text outside the slide.


### PR DESCRIPTION
## Summary
- Fix: SVG images silently dropped when href is missing or uses internal `#ref`
- Fix: Text overflows container bounds due to underestimated width

## Changes
- `svg_to_pptx/utils.py`: increase width estimation coefficients (Latin 0.55→0.62, space 0.3→0.35)
- `svg_to_pptx/elements.py`: increase text padding 1.45x→1.6x; add warning log for missing image href
- `svg_critic.py`: add `image_missing_href`, `image_internal_ref`, `text_too_close_to_edge` rules
- `prompts/executor.md`: enforce real image paths; require 40px text edge margin

## Test plan
- [ ] Generate PPTX with image-containing SVG, verify critic catches invalid hrefs
- [ ] Check exported PPTX for text overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)