### PR TITLE
fix: improve image display and reduce icon overuse

### DIFF
--- a/assets/references/executor-base.md
+++ b/assets/references/executor-base.md
@@ -64,9 +64,11 @@ File naming format: `<number>_<page_name>.svg`
 
 ---
 
-## 4. Icon Usage
+## 4. Icon Usage (Optional)
 
-Four approaches: **A: Emoji** (`<text>🚀</text>`) | **B: AI-generated** (SVG basic shapes) | **C: Built-in library** (`templates/icons/` 6700+ icons, recommended) | **D: Custom** (user-specified)
+> **Design philosophy**: Icons are optional. Most slides should use 0 icons. Only add an icon when it has a clear design purpose: marking a section header, labeling a process step, or highlighting a KPI metric. Do NOT use icons as bullet-point prefixes, list decorations, or generic filler. If no clear purpose, leave the space empty.
+
+Four approaches: **A: Emoji** (`<text>🚀</text>`) | **B: AI-generated** (SVG basic shapes) | **C: Built-in library** (`templates/icons/` 6700+ icons, recommended) | **D: Custom** (user-specified) | **E: No icons** (clean minimal style)
 
 **Built-in icons — Placeholder method (recommended)**:
 

--- a/assets/references/strategist.md
+++ b/assets/references/strategist.md
@@ -101,7 +101,9 @@ Proactively provide a color scheme (HEX values) based on content characteristics
 
 **Color rules**: 60-30-10 rule (primary 60%, secondary 30%, accent 10%); text contrast ratio >= 4.5:1; no more than 4 colors per page.
 
-### f. Icon Usage Confirmation
+### f. Icon Usage Confirmation (Optional)
+
+> **Design philosophy**: Icons are optional decorative aids, not requirements. Most slides should use 0 icons. Only add an icon when it has a clear semantic role (section header, process step label, KPI highlight). Do NOT use icons as bullet-point prefixes or generic decoration.
 
 | Option | Approach | Suitable Scenarios |
 |--------|----------|-------------------|
@@ -109,6 +111,7 @@ Proactively provide a color scheme (HEX values) based on content characteristics
 | **B** | AI-generated | Custom style needed |
 | **C** | Built-in icon library | Professional scenarios (recommended) |
 | **D** | Custom icons | Has brand assets |
+| **E** | No icons | Clean academic / minimal style |
 
 Built-in library contains 6700+ icons across three libraries:
 

--- a/assets/templates/design_spec_reference.md
+++ b/assets/templates/design_spec_reference.md
@@ -150,7 +150,17 @@
 
 ---
 
-## VI. Icon Usage Specification
+## VI. Icon Usage Specification (Optional)
+
+### Design Philosophy
+
+Icons are **optional decorative aids**. Most slides should use 0 icons. Only add an icon when:
+- It marks a **section header** or chapter divider
+- It labels a **process step** in a flowchart/framework diagram
+- It highlights a **KPI metric** or key number
+- It replaces text in a **tight layout** where space is limited
+
+Do NOT use icons as: bullet-point prefixes, list decorations, generic visual filler, or decoration for decoration's sake. If no clear purpose, leave the space empty.
 
 ### Source
 
@@ -161,15 +171,14 @@
   - 线宽统一，保持 academic clean look。
   - 图标尺寸：正文卡片 22–28px；章节标识 30–36px；封面装饰不超过 48px。
   - 图标颜色默认 `#2B6CB0`，风险/局限用 `#C05621`，提升/贡献用 `#2F855A`。
-  - 图标只用于语义引导，不作为装饰堆叠；每页建议不超过 5 个。
-  - 不使用复杂 emoji；若使用符号，仅限箭头、加号、对勾等清晰符号。
+  - 不使用复杂 emoji；若使用符号，仅限箭头、加号、对扣等清晰符号。
   - **One presentation = one library — never mix libraries.**
 
-### Recommended Icon List (fill as needed)
+### Recommended Icon List (fill only when justified)
 
-| Purpose | Icon Path | Page |
-| ------- | --------- | ---- |
-| [example] | `tabler-outline/check-circle` | Slide XX |
+| Purpose | Icon Path | Page | Justification |
+| ------- | --------- | ---- | ------------- |
+| [example] | `tabler-outline/check-circle` | Slide XX | [Why this icon is needed here] |
 
 ---
 

--- a/backend/api/endpoints/preview.py
+++ b/backend/api/endpoints/preview.py
@@ -13,6 +13,33 @@ from backend.session.manager import session_manager
 router = APIRouter()
 
 
+@router.get("/critic/{job_id}")
+async def get_critic_history(job_id: str) -> dict:
+    """Return persisted critic events from critic_history.json."""
+    import json
+
+    job = session_manager.get_job(job_id)
+    if job is None or not job.project_dir:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found.")
+
+    critic_path = Path(job.project_dir) / "critic_history.json"
+    if not critic_path.exists():
+        return {"events": []}
+
+    try:
+        data = json.loads(critic_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {"events": []}
+
+    # Merge generation and refine events
+    events = data.get("generation_events") or []
+    refine_events = data.get("refine_events") or []
+    if refine_events:
+        events = refine_events  # Prefer refine events if present
+
+    return {"events": events}
+
+
 @router.get("/critic-archive/{job_id}/{filename}")
 async def get_critic_archive_svg(job_id: str, filename: str) -> Response:
     """Serve a pre-repair archived SVG from svg_archive/repair/."""

--- a/backend/generator/svg_finalize/crop_images.py
+++ b/backend/generator/svg_finalize/crop_images.py
@@ -1,8 +1,12 @@
-"""Smart image cropping for SVG images with preserveAspectRatio="...slice"."""
+"""Fix SVG images that use preserveAspectRatio="slice".
+
+For images with preserveAspectRatio="slice", the image fills the element box
+and content is cropped. We convert to "meet" (the SVG default) so the full
+image is visible with letterboxing, without changing element dimensions.
+"""
 
 from __future__ import annotations
 
-import io
 import re
 from pathlib import Path
 
@@ -13,7 +17,10 @@ Y_MAP = {"YMin": 0.0, "YMid": 0.5, "YMax": 1.0}
 
 
 def crop_images_in_svg(svg_path: Path) -> int:
-    """Process images with slice aspect ratio, cropping to fit target dimensions.
+    """Adjust SVG image dimensions to preserve full image content.
+
+    For images with preserveAspectRatio="slice", converts to default "meet"
+    behavior so the full image is visible without cropping.
 
     Returns:
         Number of images processed.
@@ -32,7 +39,6 @@ def crop_images_in_svg(svg_path: Path) -> int:
 
     root = tree.getroot()
     svg_dir = svg_path.parent
-    cropped_dir = svg_dir.parent / "images" / "cropped"
     count = 0
 
     for elem in root.iter():
@@ -71,23 +77,13 @@ def crop_images_in_svg(svg_path: Path) -> int:
 
         try:
             img = Image.open(img_path)
-            cropped = _crop_to_aspect(img, target_w, target_h, align)
-            if cropped is None:
+            img_w, img_h = img.size
+            if img_w <= 0 or img_h <= 0:
                 continue
 
-            cropped_dir.mkdir(parents=True, exist_ok=True)
-            out_path = cropped_dir / img_path.name
-            fmt = "PNG" if img_path.suffix.lower() == ".png" else "JPEG"
-            if fmt == "JPEG" and cropped.mode == "RGBA":
-                cropped = cropped.convert("RGB")
-            cropped.save(out_path, format=fmt, quality=90, optimize=True)
-
-            # Update SVG element
-            rel_path = f"../images/cropped/{img_path.name}"
-            if f"{{{XLINK_NS}}}href" in elem.attrib:
-                elem.set(f"{{{XLINK_NS}}}href", rel_path)
-            else:
-                elem.set("href", rel_path)
+            # Just remove "slice" — browser default "meet" will show the
+            # full image with letterboxing. Keep original element dimensions
+            # to preserve layout.
             if "preserveAspectRatio" in elem.attrib:
                 del elem.attrib["preserveAspectRatio"]
             count += 1
@@ -116,32 +112,8 @@ def _parse_par(par: str) -> tuple[dict | None, str]:
     return {"x": X_MAP[x_match.group(1)], "y": Y_MAP[y_match.group(1)]}, mode
 
 
-def _crop_to_aspect(
-    img: Image.Image,
-    target_w: float,
-    target_h: float,
-    align: dict,
-) -> Image.Image | None:
-    """Crop image to match target aspect ratio using alignment anchor."""
-    img_w, img_h = img.size
-    target_ratio = target_w / target_h
-    img_ratio = img_w / img_h
-
-    if abs(img_ratio - target_ratio) < 0.01:
-        return None  # Already correct ratio
-
-    if img_ratio > target_ratio:
-        # Wider than target, crop sides
-        crop_h = img_h
-        crop_w = int(img_h * target_ratio)
-    else:
-        # Taller than target, crop top/bottom
-        crop_w = img_w
-        crop_h = int(img_w / target_ratio)
-
-    extra_w = img_w - crop_w
-    extra_h = img_h - crop_h
-    left = int(extra_w * align["x"])
-    top = int(extra_h * align["y"])
-
-    return img.crop((left, top, left + crop_w, top + crop_h))
+def _fmt(val: float) -> str:
+    """Format float compactly."""
+    if val == int(val):
+        return str(int(val))
+    return f"{val:.2f}".rstrip("0").rstrip(".")

--- a/backend/orchestrator/pipeline.py
+++ b/backend/orchestrator/pipeline.py
@@ -164,6 +164,8 @@ async def run_pipeline(
             enable_icon=request.enable_icon,
             enable_icon_rag=request.enable_icon_rag,
             gemini_api_key=request.gemini_api_key,
+            figure_inventory=figure_inventory,
+            debug_dir=project_dir / "debug",
         )
 
         # Save design spec
@@ -492,6 +494,7 @@ async def run_refine_pipeline(
         yield ProgressEvent("research", "complete", "Manuscript revised", 0.15)
 
         yield ProgressEvent("strategy", "started", "Rebuilding design specification...", 0.15)
+        refine_figure_inventory = _load_figure_inventory(project_dir)
         design_spec = await strategist_agent.create_design_spec(
             manuscript,
             llm,
@@ -505,6 +508,7 @@ async def run_refine_pipeline(
             enable_icon=request.enable_icon,
             enable_icon_rag=request.enable_icon_rag,
             gemini_api_key=request.gemini_api_key,
+            figure_inventory=refine_figure_inventory,
         )
         design_spec_path.write_text(design_spec, encoding="utf-8")
         yield ProgressEvent("strategy", "complete", "Design spec rebuilt", 0.30)

--- a/backend/orchestrator/prompts/executor.md
+++ b/backend/orchestrator/prompts/executor.md
@@ -40,6 +40,17 @@ One complete SVG file per page with proper viewBox.
 <use data-icon="tabler-outline/arrow-right" x="100" y="200" width="24" height="24" fill="#333"/>
 ```
 
+### Icon Usage Rules
+- Icons are **optional**. Most slides should use 0 icons.
+- Only add an icon when it has a clear design purpose:
+  - Section header marker (next to a chapter/part title)
+  - Process step label (in a flowchart or framework diagram)
+  - KPI metric highlight (next to a key number)
+- Do NOT use icons as bullet-point prefixes, list decorations, or generic filler.
+- If an icon doesn't serve a clear purpose, leave it out — empty space is fine.
+- **Title slide**: at most 1 decorative icon (e.g. topic-related emblem)
+- **Content / data slides**: 0–2 icons maximum, only where justified
+
 ## Generation Rules
 
 1. Generate pages **sequentially**, one at a time

--- a/backend/orchestrator/prompts/strategist.md
+++ b/backend/orchestrator/prompts/strategist.md
@@ -22,7 +22,11 @@ Follow this structure exactly:
 ### V. Layout Principles
 - Grid system, spacing rules, alignment guidelines
 
-### VI. Icon Usage
+### VI. Icon Usage (Optional)
+- Icons are **optional decorative aids**, not requirements. Most slides need 0 icons.
+- Only add an icon when it has a clear semantic role: marking a section header, labeling a process step, or highlighting a KPI metric.
+- Do NOT use icons as bullet-point prefixes, list decorations, or generic visual filler.
+- If an icon doesn't serve a clear purpose on a slide, leave it out — empty space is better than forced decoration.
 - Icon library preference (chunk/tabler-filled/tabler-outline)
 - Icon style guidelines, size constraints
 

--- a/backend/orchestrator/strategist_agent.py
+++ b/backend/orchestrator/strategist_agent.py
@@ -22,9 +22,9 @@ DESIGN_SPEC_MAX_TOKENS = 24576
 MAX_DESIGN_SPEC_ATTEMPTS = 2
 
 # Number of icon candidates to pre-select via RAG
-ICON_CANDIDATE_COUNT = 60
+ICON_CANDIDATE_COUNT = 30
 # Number of search queries to extract from manuscript
-ICON_QUERY_COUNT = 12
+ICON_QUERY_COUNT = 8
 
 
 def _extract_icon_queries(manuscript: str) -> list[str]:
@@ -105,10 +105,12 @@ def _retrieve_icon_candidates(
 
     # Format as a compact table for prompt injection
     lines = [
-        f"\n## Pre-selected Icon Candidates ({lib} library, {len(candidates)} icons)",
+        f"\n## Available Icon Candidates ({lib} library, {len(candidates)} icons)",
         "",
-        "These icons were retrieved by semantic search from the full icon index "
-        "based on your manuscript content. **You MUST choose icons from this list.**",
+        "These icons were retrieved by semantic search based on your manuscript content. "
+        "They are **optional resources** — only use an icon when it has a clear semantic role "
+        "(e.g., marking a section header, labeling a process step, highlighting a KPI). "
+        "Do NOT use icons as bullet-point prefixes or generic decoration.",
         "",
         "| # | Icon Path | Category | Tags |",
         "|---|-----------|----------|------|",
@@ -123,6 +125,12 @@ def _retrieve_icon_candidates(
     lines.append(
         "Use the icon path with the `<use data-icon=\"...\"/>` placeholder syntax. "
         "Example: `<use data-icon=\"chart-bar\" x=\"100\" y=\"200\" width=\"32\" height=\"32\" fill=\"#0076A8\"/>`"
+    )
+    lines.append("")
+    lines.append(
+        "**Important**: These are optional candidates. Most slides should use 0 icons. "
+        "Only add an icon when it has a clear design purpose — do NOT use icons as "
+        "bullet prefixes or decoration."
     )
 
     return "\n".join(lines)
@@ -177,6 +185,8 @@ async def create_design_spec(
     enable_icon: bool = True,
     enable_icon_rag: bool = True,
     gemini_api_key: str | None = None,
+    figure_inventory: list[dict] | None = None,
+    debug_dir: Path | None = None,
 ) -> str:
     """Generate a design specification from a manuscript.
 
@@ -246,6 +256,33 @@ async def create_design_spec(
     if icon_candidates_block:
         user_parts.append(icon_candidates_block)
 
+    # Inject actual image dimensions so the design spec has correct ratios
+    if figure_inventory:
+        fig_lines = ["\n## Available Paper Figures (actual dimensions)"]
+        fig_lines.append("")
+        fig_lines.append("Use these EXACT dimensions and ratios in Section VIII Image Resource List.")
+        fig_lines.append("Do NOT fabricate dimensions — use the actual values below.")
+        fig_lines.append("")
+        fig_lines.append("| Filename | Actual Dimensions | Ratio | Page | Caption |")
+        fig_lines.append("|----------|-------------------|-------|------|---------|")
+        for fig in figure_inventory:
+            w = fig.get("natural_width", 0)
+            h = fig.get("natural_height", 0)
+            ratio = fig.get("aspect_ratio", 0)
+            page = fig.get("page_number", "?")
+            path = fig.get("path", "")
+            name = Path(path).stem if path else "?"
+            cap = (fig.get("caption") or "")[:60]
+            if w and h:
+                fig_lines.append(f"| {name} | {w}x{h} | {ratio:.2f} | p{page} | {cap} |")
+        fig_lines.append("")
+        fig_lines.append(
+            "**Important**: When placing these images in SVG, the `width/height` ratio MUST match "
+            "the actual ratio above. For example, if actual dimensions are 974x269 (ratio 3.62), "
+            "use width=500 height=138 (500/3.62≈138)."
+        )
+        user_parts.append("\n".join(fig_lines))
+
     if style_overrides:
         override_lines = ["\n## Style Overrides (must override defaults)"]
         palette = style_overrides.get("palette") if isinstance(style_overrides, dict) else None
@@ -286,6 +323,18 @@ async def create_design_spec(
         LLMMessage.system(system_prompt),
         LLMMessage.user("\n".join(user_parts)),
     ]
+
+    # Save full prompt for debugging
+    if debug_dir:
+        try:
+            debug_dir.mkdir(parents=True, exist_ok=True)
+            prompt_file = debug_dir / "strategist_prompt.md"
+            parts = []
+            for msg in base_messages:
+                parts.append(f"--- ROLE: {msg.role} ---\n\n{msg.content}")
+            prompt_file.write_text("\n\n".join(parts), encoding="utf-8")
+        except Exception:
+            pass
 
     last_error = ""
     for attempt in range(1, MAX_DESIGN_SPEC_ATTEMPTS + 1):

--- a/backend/orchestrator/svg_executor.py
+++ b/backend/orchestrator/svg_executor.py
@@ -321,6 +321,18 @@ async def generate_svg_pages(
         ),
     ]
 
+    # Save full initial prompt for debugging
+    try:
+        debug_dir = project_dir / "debug"
+        debug_dir.mkdir(parents=True, exist_ok=True)
+        prompt_file = debug_dir / "executor_prompt.md"
+        parts = []
+        for msg in conversation:
+            parts.append(f"--- ROLE: {msg.role} ---\n\n{msg.content}")
+        prompt_file.write_text("\n\n".join(parts), encoding="utf-8")
+    except Exception:
+        pass
+
     # Track how many page exchanges we've appended beyond the preamble
     # (system + design-spec user + ack assistant = 3 preamble messages).
     _preamble_len = len(conversation)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -175,6 +175,10 @@ export async function deleteVersion(jobId: string, roundName: string): Promise<v
   await request<void>(`/api/versions/${jobId}/${roundName}`, { method: "DELETE" });
 }
 
+export async function fetchCriticHistory(jobId: string): Promise<{ events: import("./types").CriticEvent[] }> {
+  return request<{ events: import("./types").CriticEvent[] }>(`/api/critic/${jobId}`);
+}
+
 export async function fetchUsageSnapshot(): Promise<UsageSnapshotResponse> {
   const [summary, daily, byModel, byStage, records] = await Promise.all([
     request<UsageSummaryResponse>("/api/usage/summary"),

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -9,9 +9,9 @@ import { ProgressPanel } from "../components/progress/ProgressPanel";
 import { VersionHistory } from "../components/result/VersionHistory";
 import { useGeneration } from "../hooks/useGeneration";
 import { useLocale } from "../i18n";
-import { fetchJobStatus, fetchPreview, fetchProjectPreview, getDownloadUrl, getDownloadUrlForOutput, isNotFoundError, reexportPresentation } from "../lib/api";
+import { fetchCriticHistory, fetchJobStatus, fetchPreview, fetchProjectPreview, getDownloadUrl, getDownloadUrlForOutput, isNotFoundError, reexportPresentation } from "../lib/api";
 import { translateStageStatus } from "../lib/i18nStatus";
-import type { DeepSeekSettings, GenerateRequestPayload, GenerationHistoryItem, JobStatus, OpenAISettings, PreviewResponse, PreviewSlide } from "../lib/types";
+import type { CriticEvent, DeepSeekSettings, GenerateRequestPayload, GenerationHistoryItem, JobStatus, OpenAISettings, PreviewResponse, PreviewSlide } from "../lib/types";
 
 // Routing profile stored by GeneratePage so we can re-use model config here.
 const ROUTING_PROFILE_STORAGE_KEY = "paper-ppt-agent-routing-profiles-v1";
@@ -64,24 +64,37 @@ export function ResultPage() {
     job: liveJob,
     slides: liveSlides,
     result: liveResult,
-    logs,
-    criticEvents,
+    logs: globalLogs,
+    criticEvents: globalCriticEvents,
     connectionStatus,
-    currentRunConfig,
+    currentRunConfig: globalRunConfig,
+    runs,
   } = useGeneration();
+
+  // Read logs, criticEvents, and config from the specific run matching the
+  // URL jobId instead of the global top-level state.  The global fields
+  // always reflect the *last active* run, so opening a historical task
+  // would incorrectly show that run's data instead of the requested one.
+  const [remoteCriticEvents, setRemoteCriticEvents] = useState<CriticEvent[] | null>(null);
+  const resolvedRun = jobId ? runs[jobId] : undefined;
+  const isActiveJob = jobId === activeJobId;
+  const logs = isActiveJob ? globalLogs : (resolvedRun?.logs ?? []);
+  const localCritic = isActiveJob ? globalCriticEvents : (resolvedRun?.criticEvents ?? []);
+  const criticEvents = localCritic.length > 0 ? localCritic : (remoteCriticEvents ?? []);
+  const currentRunConfig = isActiveJob ? globalRunConfig : (resolvedRun?.currentRunConfig);
   // Direct-bind the global error-store setters so we can mirror local
   // page errors (load / refine / reexport / failed-job) into the global
   // error slot — that's what drives the floating ErrorBanner.
   const setGlobalError = (msg: string | undefined) =>
     useGeneration.setState({ error: msg });
 
-  const historyEntry = history.find((entry) => entry.jobId === jobId);
   const [result, setResult] = useState<PreviewResponse | null>(null);
   const [job, setJob] = useState<JobStatus | null>(null);
   const [slides, setSlides] = useState<PreviewSlide[]>([]);
   const [selectedSlide, setSelectedSlide] = useState<PreviewSlide | undefined>(undefined);
   const [loadError, setLoadError] = useState<string | null>(null);
 
+  const historyEntry = history.find((entry) => entry.jobId === jobId);
   const outputPath = job?.output_path ?? result?.output_path ?? historyEntry?.outputPath;
   const downloadHref = outputPath
     ? getDownloadUrlForOutput(outputPath)
@@ -212,6 +225,27 @@ export function ResultPage() {
   useEffect(() => {
     setSelectedSlide((current) => pickSelectedSlide(slides, current));
   }, [slides]);
+
+  // Fetch critic events from backend when local data is empty (e.g. after
+  // page refresh or server restart).  The backend persists critic events to
+  // critic_history.json so they survive across sessions.
+  useEffect(() => {
+    if (!jobId || localCritic.length > 0 || isActiveJob) {
+      setRemoteCriticEvents(null);
+      return;
+    }
+    let cancelled = false;
+    fetchCriticHistory(jobId)
+      .then((data) => {
+        if (!cancelled && Array.isArray(data.events) && data.events.length > 0) {
+          setRemoteCriticEvents(data.events as CriticEvent[]);
+        }
+      })
+      .catch(() => {
+        // Silently ignore — critic data is optional
+      });
+    return () => { cancelled = true; };
+  }, [jobId, localCritic.length, isActiveJob]);
 
   // Mirror any active page-level error into the global ``error`` store so
   // the floating ErrorBanner becomes visible. Priority order:


### PR DESCRIPTION
## Summary
- Pass actual image dimensions from figure_inventory to strategist so design spec uses real aspect ratios instead of fabricated 800x450
- Simplify crop_images.py to only remove preserveAspectRatio="slice" (browser default "meet" handles letterboxing correctly)
- Make icons optional in all prompts — "most slides should use 0 icons"
- Fix historical task page Agent Log/Config/Critic display (read from runs[jobId] instead of global state)
- Add critic history endpoint for completed task pages
- Save full strategist/executor prompts to debug/ directory for inspection

## Test plan
- [ ] Generate a new project and verify design spec uses actual image dimensions
- [ ] Verify SVG images display fully without cropping
- [ ] Verify icons are used sparingly (not as bullet prefixes)
- [ ] Check debug/ directory contains complete prompt files
- [ ] Verify historical task pages show correct logs/config/critic

🤖 Generated with [Claude Code](https://claude.com/claude-code)