### PR TITLE
refactor: deduplicate and trim strategist/executor prompts

### DIFF
--- a/assets/references/shared-standards-essential.md
+++ b/assets/references/shared-standards-essential.md
@@ -1,0 +1,145 @@
+# SVG Technical Standards (Essential)
+
+Core technical constraints for SVG generation. For advanced techniques (shadows, gradients, arc paths, polygon arrows), refer to `shared-standards.md` §6–§7.
+
+---
+
+## 1. SVG Banned Features Blacklist
+
+The following features are **absolutely forbidden** — PPT export will break if any are used:
+
+| Banned Feature | Description |
+|----------------|-------------|
+| `mask` | Masks |
+| `<style>` | Embedded stylesheets |
+| `class` | CSS selector attributes (`id` inside `<defs>` is legitimate) |
+| External CSS | External stylesheet links |
+| `<foreignObject>` | Embedded external content |
+| `<symbol>` + `<use>` | Symbol reference reuse (except icon placeholders) |
+| `textPath` | Text along a path |
+| `@font-face` | Custom font declarations |
+| `<animate*>` / `<set>` | SVG animations |
+| `<script>` / event attributes | Scripts and interactivity |
+| `<iframe>` | Embedded frames |
+
+> **`marker-start` / `marker-end`** and **`clipPath` on `<image>`** are conditionally allowed — see below.
+
+---
+
+### 1.1 Line-end Markers (Conditionally Allowed)
+
+`marker-start` / `marker-end` on `<line>` and `<path>` are allowed **only** when the referenced `<marker>` satisfies **all** of:
+
+| Requirement | Reason |
+|-------------|--------|
+| Defined inside `<defs>` | Converter looks up marker defs via id index |
+| `orient="auto"` | DrawingML arrow auto-rotates along the line tangent |
+| Shape is triangle / diamond / oval | Other shapes are silently dropped |
+| Child `fill` matches parent line `stroke` | Inherited in DrawingML — mismatch looks wrong |
+| `markerWidth` / `markerHeight` in `3–15` range | Mapped to sm/med/lg size buckets |
+
+**Template**:
+```xml
+<defs>
+  <marker id="arrowHead" markerWidth="10" markerHeight="10" refX="9" refY="5"
+          orient="auto" markerUnits="strokeWidth">
+    <path d="M0,0 L10,5 L0,10 Z" fill="#1976D2"/>
+  </marker>
+</defs>
+<line x1="100" y1="200" x2="400" y2="200" stroke="#1976D2" stroke-width="3"
+      marker-end="url(#arrowHead)"/>
+```
+
+For block/chunky arrows, use standalone `<polygon>` instead of `marker`.
+
+---
+
+### 1.2 Image Clipping (Conditionally Allowed)
+
+`clip-path` on `<image>` is allowed when the `<clipPath>` contains a **single** shape child (`<circle>`, `<rect rx>`, `<path>`, `<polygon>`). **Only on `<image>` elements** — never on shapes or groups.
+
+---
+
+## 2. PPT Compatibility Alternatives
+
+| Banned | Correct Alternative |
+|--------|---------------------|
+| `fill="rgba(255,255,255,0.1)"` | `fill="#FFFFFF" fill-opacity="0.1"` |
+| `<g opacity="0.2">...</g>` | Set `fill-opacity` / `stroke-opacity` on each child |
+| `<image opacity="0.3"/>` | Overlay `<rect fill="bg-color" opacity="0.7"/>` after the image |
+
+**Mnemonic**: PPT does not recognize rgba, group opacity, or image opacity.
+
+---
+
+## 3. Canvas Format Quick Reference
+
+| Format | viewBox | Dimensions |
+|--------|---------|------------|
+| PPT 16:9 | `0 0 1280 720` | 1280x720 |
+| PPT 4:3 | `0 0 1024 768` | 1024x768 |
+
+---
+
+## 4. Basic SVG Rules
+
+- **viewBox** must match canvas dimensions
+- **Background**: Use `<rect>` for page background
+- **Line breaks**: Use `<tspan>`; `<foreignObject>` is FORBIDDEN
+- **Fonts**: System fonts only (Microsoft YaHei, Arial, Calibri); `@font-face` is FORBIDDEN
+- **Styles**: Inline only (`fill="..."` `font-size="..."`); `<style>` / `class` are FORBIDDEN
+- **Colors**: HEX values; transparency via `fill-opacity` / `stroke-opacity`
+- **Images**: `<image href="../images/xxx.png" preserveAspectRatio="xMidYMid slice"/>`
+- **Icons**: `<use data-icon="library/name" x="" y="" width="48" height="48" fill="#HEX"/>`. **One presentation = one library — never mix.**
+
+### Element Grouping (Mandatory)
+
+Logically related elements **MUST** be wrapped in `<g>` tags for PowerPoint grouping.
+
+> ⚠️ **Only `<g opacity="...">` is banned.** Plain `<g>` for structure is required.
+
+| Group | Contains |
+|-------|----------|
+| Card / panel | Background rect + shadow + icon + title + body |
+| Process step | Number circle + icon + label + description |
+| List item | Bullet + icon + title + description |
+| Page header | Title + subtitle + accent decoration |
+| Page footer | Page number + branding |
+
+Use descriptive `id` attributes (e.g. `card-1`, `step-discover`, `header`, `footer`).
+
+---
+
+## 5. Post-processing Pipeline (3 Steps)
+
+Must be executed in order:
+
+```bash
+# 1. Split speaker notes into per-page files
+python3 scripts/total_md_split.py <project_path>
+
+# 2. SVG post-processing (icon embed, image crop, text flatten, rounded rect → path)
+python3 scripts/finalize_svg.py <project_path>
+
+# 3. Export PPTX (from svg_final/)
+python3 scripts/svg_to_pptx.py <project_path> -s final
+```
+
+**Prohibited**: NEVER use `cp` as substitute for `finalize_svg.py`. NEVER export from `svg_output/` — MUST use `svg_final/`.
+
+**Re-run rule**: Any modification to `svg_output/` after post-processing requires re-running Steps 2 and 3.
+
+---
+
+## 6. Project Directory Structure
+
+```
+project/
+├── svg_output/    # Raw SVGs (Executor output)
+├── svg_final/     # Post-processed SVGs (finalize_svg.py output)
+├── images/        # Image assets
+├── notes/         # Speaker notes (.md files matching SVG names)
+│   └── total.md   # Complete speaker notes (before splitting)
+├── templates/     # Project templates
+└── *.pptx         # Exported PPT file
+```

--- a/assets/templates/design_spec_reference.md
+++ b/assets/templates/design_spec_reference.md
@@ -152,27 +152,7 @@
 
 ## VI. Icon Usage Specification (Optional)
 
-### Design Philosophy
-
-Icons are **optional decorative aids**. Most slides should use 0 icons. Only add an icon when:
-- It marks a **section header** or chapter divider
-- It labels a **process step** in a flowchart/framework diagram
-- It highlights a **KPI metric** or key number
-- It replaces text in a **tight layout** where space is limited
-
-Do NOT use icons as: bullet-point prefixes, list decorations, generic visual filler, or decoration for decoration's sake. If no clear purpose, leave the space empty.
-
-### Source
-
-- **Built-in icon library**: `templates/icons/` (6700+ icons across three libraries)
-- **Usage method**: SVG placeholder format `<use data-icon="category/icon-name" x="" y="" width="" height="" fill="#HEX"/>`
-- **Recommended Library**: `tabler-outline` 为主；必要时对结果页使用少量 `tabler-filled` 强调正向结果。
-- **Icon Style Guidelines**:
-  - 线宽统一，保持 academic clean look。
-  - 图标尺寸：正文卡片 22–28px；章节标识 30–36px；封面装饰不超过 48px。
-  - 图标颜色默认 `#2B6CB0`，风险/局限用 `#C05621`，提升/贡献用 `#2F855A`。
-  - 不使用复杂 emoji；若使用符号，仅限箭头、加号、对扣等清晰符号。
-  - **One presentation = one library — never mix libraries.**
+Icons are optional. Most slides need 0 icons. Only add when it has a clear semantic role (section header, process step, KPI highlight). Never use as bullet prefixes or generic decoration.
 
 ### Recommended Icon List (fill only when justified)
 

--- a/backend/orchestrator/prompts/executor.md
+++ b/backend/orchestrator/prompts/executor.md
@@ -5,51 +5,21 @@ You are an expert SVG page generator for presentations. Given a design specifica
 ## Input
 - `design_spec.md`: Complete visual specification
 - Page number and content to render
-- Layout templates for reference
 
 ## Output
 One complete SVG file per page with proper viewBox.
 
-## SVG Requirements
-
-### Canvas
+## Canvas
 ```xml
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
 ```
 
-### BANNED Features (will cause export failure)
-- `<mask>`, `<style>`, `class` attributes, external CSS
-- `<foreignObject>`, `<symbol>` + `<use>` (except icon placeholders)
-- `textPath`, `@font-face`
-- SVG animations (`<animate*>`), `<script>`, `<iframe>`
-
-### ALLOWED Features
+## ALLOWED Features (quick reference)
 - `<defs>` with `<linearGradient>`, `<radialGradient>`
 - `<clipPath>` on `<image>` only (single shape child)
 - `marker-start` / `marker-end` (triangle/diamond/oval shapes only)
 
-### PPT Compatibility Alternatives
-| Banned | Use Instead |
-|--------|-------------|
-| `rgba()` | `fill-opacity` / `stroke-opacity` |
-| `<g opacity>` | Per-child opacity |
-
-### Icon Placeholders
-```xml
-<use data-icon="chart-bar" x="100" y="200" width="32" height="32" fill="#0076A8"/>
-<use data-icon="tabler-outline/arrow-right" x="100" y="200" width="24" height="24" fill="#333"/>
-```
-
-### Icon Usage Rules
-- Icons are **optional**. Most slides should use 0 icons.
-- Only add an icon when it has a clear design purpose:
-  - Section header marker (next to a chapter/part title)
-  - Process step label (in a flowchart or framework diagram)
-  - KPI metric highlight (next to a key number)
-- Do NOT use icons as bullet-point prefixes, list decorations, or generic filler.
-- If an icon doesn't serve a clear purpose, leave it out — empty space is fine.
-- **Title slide**: at most 1 decorative icon (e.g. topic-related emblem)
-- **Content / data slides**: 0–2 icons maximum, only where justified
+All banned features, PPT compatibility rules, and technical constraints are in `## SVG Technical Standards` below — follow them exactly.
 
 ## Generation Rules
 

--- a/backend/orchestrator/prompts/strategist.md
+++ b/backend/orchestrator/prompts/strategist.md
@@ -23,12 +23,9 @@ Follow this structure exactly:
 - Grid system, spacing rules, alignment guidelines
 
 ### VI. Icon Usage (Optional)
-- Icons are **optional decorative aids**, not requirements. Most slides need 0 icons.
-- Only add an icon when it has a clear semantic role: marking a section header, labeling a process step, or highlighting a KPI metric.
-- Do NOT use icons as bullet-point prefixes, list decorations, or generic visual filler.
-- If an icon doesn't serve a clear purpose on a slide, leave it out — empty space is better than forced decoration.
-- Icon library preference (chunk/tabler-filled/tabler-outline)
-- Icon style guidelines, size constraints
+- Icons are optional. Most slides need 0 icons.
+- Only add when it has a clear semantic role: section header, process step, or KPI highlight.
+- Never use as bullet prefixes or generic decoration. Empty space is better than forced icons.
 
 ### VII. Visualization Reference List
 - Recommended chart types for data in the manuscript

--- a/backend/orchestrator/provider_guidance.py
+++ b/backend/orchestrator/provider_guidance.py
@@ -29,14 +29,13 @@ def is_deepseek_provider(llm: LLMProvider, model: str) -> bool:
 def deepseek_research_guidance(detail_level: str) -> str:
     if detail_level != "very_high":
         return (
-            "## DeepSeek Calibration\n\n"
+            "## Detail Level Guidelines\n\n"
             "Preserve concrete paper details in the final answer. Avoid collapsing method, "
             "evidence, or result slides into generic labels."
         )
     return (
-        "## DeepSeek Calibration\n\n"
-        "DeepSeek can be overly terse in its final answer after reasoning. For this "
-        "`very_high` deck, keep the final manuscript analytically dense but still "
+        "## Detail Level Guidelines\n\n"
+        "For this `very_high` deck, keep the final manuscript analytically dense but still "
         "slide-ready:\n"
         "- For each substantive slide, include mechanism, evidence/data, and implication "
         "when the paper provides them.\n"
@@ -53,12 +52,12 @@ def deepseek_research_guidance(detail_level: str) -> str:
 def deepseek_strategy_guidance(detail_level: str) -> str:
     if detail_level != "very_high":
         return (
-            "## DeepSeek Calibration\n\n"
+            "## Detail Level Guidelines\n\n"
             "Convert manuscript substance into concrete layout plans. Do not reduce rich "
             "slides to decorative tags or short labels."
         )
     return (
-        "## DeepSeek Calibration\n\n"
+        "## Detail Level Guidelines\n\n"
         "For `very_high`, the design spec must preserve the manuscript's analytical "
         "depth while keeping layouts readable:\n"
         "- In section IX, each non-cover page must list the concrete content blocks to "
@@ -76,12 +75,12 @@ def deepseek_strategy_guidance(detail_level: str) -> str:
 def deepseek_executor_guidance(detail_level: str) -> str:
     if detail_level != "very_high":
         return (
-            "## DeepSeek Execution Calibration\n\n"
+            "## Detail Level Guidelines\n\n"
             "Keep the SVG faithful to the manuscript. Do not collapse content into a "
             "few generic tags when there is room for concise explanatory text."
         )
     return (
-        "## DeepSeek Execution Calibration\n\n"
+        "## Detail Level Guidelines\n\n"
         "For `very_high`, preserve depth without overcrowding:\n"
         "- Each substantive slide should render the manuscript's core mechanism, "
         "evidence/data, and implication when present.\n"

--- a/backend/orchestrator/strategist_agent.py
+++ b/backend/orchestrator/strategist_agent.py
@@ -107,10 +107,7 @@ def _retrieve_icon_candidates(
     lines = [
         f"\n## Available Icon Candidates ({lib} library, {len(candidates)} icons)",
         "",
-        "These icons were retrieved by semantic search based on your manuscript content. "
-        "They are **optional resources** — only use an icon when it has a clear semantic role "
-        "(e.g., marking a section header, labeling a process step, highlighting a KPI). "
-        "Do NOT use icons as bullet-point prefixes or generic decoration.",
+        "Semantic-searched from manuscript content. Use only when justified by clear design purpose.",
         "",
         "| # | Icon Path | Category | Tags |",
         "|---|-----------|----------|------|",
@@ -127,11 +124,6 @@ def _retrieve_icon_candidates(
         "Example: `<use data-icon=\"chart-bar\" x=\"100\" y=\"200\" width=\"32\" height=\"32\" fill=\"#0076A8\"/>`"
     )
     lines.append("")
-    lines.append(
-        "**Important**: These are optional candidates. Most slides should use 0 icons. "
-        "Only add an icon when it has a clear design purpose — do NOT use icons as "
-        "bullet prefixes or decoration."
-    )
 
     return "\n".join(lines)
 
@@ -231,7 +223,6 @@ async def create_design_spec(
         f"- Style: {style_info['name']}",
         f"- Primary Color: {style_info['primary']}",
         f"- Accent Color: {style_info['accent']}",
-        "- Compact symbols are optional; use only when they carry clear semantic value.",
         f"- Typography: Sans-serif (Inter/Arial for body, bold for headings)",
         "\n## Hard Constraints",
         "- Respect the selected design style. Do not silently fall back to a default academic theme when another style is selected.",

--- a/backend/orchestrator/svg_executor.py
+++ b/backend/orchestrator/svg_executor.py
@@ -282,7 +282,9 @@ async def generate_svg_pages(
     """Generate SVG code for each slide page sequentially."""
     system_prompt = PROMPT_PATH.read_text(encoding="utf-8")
 
-    standards_path = settings.references_dir / "shared-standards.md"
+    standards_path = settings.references_dir / "shared-standards-essential.md"
+    if not standards_path.exists():
+        standards_path = settings.references_dir / "shared-standards.md"
     standards = ""
     if standards_path.exists():
         standards = standards_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Deduplicate icon usage rules across strategist system prompt, user message, and design_spec_reference template
- Rename "DeepSeek Calibration" → "Detail Level Guidelines" (model-agnostic)
- Remove redundant BANNED/Icon/PPT sections from executor.md (already in shared-standards)
- Create `shared-standards-essential.md` (78% smaller, trims shadow/stroke reference sections)
- Executor loads condensed standards by default

## Impact
- Executor prompt: ~1170 lines → ~600 lines (~45% reduction)
- Strategist prompt: ~650 lines → ~570 lines (~10% reduction)
- Eliminates all identified duplicate/ambiguous patterns

## Test plan
- [x] Python compile check on all modified files
- [x] Verify no old patterns remain (DeepSeek Calibration, Compact symbols, optional resources, BANNED Features duplication)
- [x] Compare debug prompt line counts before/after