### PR TITLE
fix: research API key persistence, async runtime, scheduler refactor

### DIFF
--- a/backend/api/endpoints/download.py
+++ b/backend/api/endpoints/download.py
@@ -77,7 +77,13 @@ async def reexport_presentation(job_id: str) -> ReexportResponse:
     canvas_format = job.canvas_format or "ppt169"
     output_path = project_dir / "exports" / f"presentation_{timestamp}.pptx"
 
-    create_pptx(
+    from backend.runtime import aoffload
+
+    # PPTX assembly is python-pptx + zipfile + cairosvg — all synchronous and
+    # CPU-heavy (5–20s for a long deck). Offload so re-export from the result
+    # page doesn't freeze the API while it runs.
+    await aoffload(
+        create_pptx,
         svg_files,
         output_path,
         canvas_format=canvas_format,

--- a/backend/api/endpoints/font_replace.py
+++ b/backend/api/endpoints/font_replace.py
@@ -13,6 +13,7 @@ from backend.generator.pptx_font_editor import (
     replace_fonts_in_pptx,
     replace_fonts_in_svg_dir,
 )
+from backend.runtime import aoffload
 from backend.session.manager import session_manager
 
 router = APIRouter()
@@ -67,7 +68,12 @@ async def apply_fonts(job_id: str, request: FontReplaceRequest) -> FontReplaceRe
     output_path = project_dir / "exports" / f"presentation_{timestamp}_fonts.pptx"
 
     try:
-        final_path, edit_result = replace_fonts_in_pptx(
+        # PPTX font replacement opens the .pptx with python-pptx and
+        # rewrites every <a:rPr typeface=…> entry — fast in CPU but fully
+        # synchronous file IO. Offload so concurrent generations on the
+        # same server aren't blocked while a font swap is in flight.
+        final_path, edit_result = await aoffload(
+            replace_fonts_in_pptx,
             source_pptx,
             config,
             output_path=output_path,
@@ -82,7 +88,7 @@ async def apply_fonts(job_id: str, request: FontReplaceRequest) -> FontReplaceRe
     svg_fonts_replaced = 0
     for svg_dir_name in ("svg_final", "svg_output"):
         svg_dir = project_dir / svg_dir_name
-        svg_fonts_replaced += replace_fonts_in_svg_dir(svg_dir, config)
+        svg_fonts_replaced += await aoffload(replace_fonts_in_svg_dir, svg_dir, config)
 
     return FontReplaceResponse(
         output_path=str(final_path),

--- a/backend/api/endpoints/font_update.py
+++ b/backend/api/endpoints/font_update.py
@@ -13,6 +13,7 @@ from backend.generator.svg_finalize.normalize_fonts import (
     FontReplaceConfig,
     replace_fonts_in_svg_dir,
 )
+from backend.runtime import aoffload
 from backend.session.manager import session_manager
 
 router = APIRouter()
@@ -61,6 +62,6 @@ async def update_svg_fonts(job_id: str, request: UpdateFontsRequest) -> UpdateFo
 
     total = 0
     for subdir in ("svg_final", "svg_output"):
-        total += replace_fonts_in_svg_dir(project_dir / subdir, config)
+        total += await aoffload(replace_fonts_in_svg_dir, project_dir / subdir, config)
 
     return UpdateFontsResponse(svg_fonts_replaced=total)

--- a/backend/api/endpoints/generate.py
+++ b/backend/api/endpoints/generate.py
@@ -1,15 +1,26 @@
-"""Generation API endpoint."""
+"""Generation API endpoint.
+
+The HTTP handler does the cheap synchronous work (validate session, derive
+the pipeline request, register a Job row) and then enqueues the actual
+generation through the scheduler. Submitting through the scheduler is what
+makes ``POST /generate`` return in milliseconds even when an earlier job is
+still in its parsing/research stage on a busy server.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
 
 from backend.api.schemas import GenerateRequest, GenerateResponse
+from backend.runtime.scheduler import QueueFull, SchedulerDraining, get_scheduler
 from backend.session.manager import session_manager
 from backend.session.progress import payloads_from_progress_event
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -148,6 +159,34 @@ async def generate_presentation(request: GenerateRequest) -> GenerateResponse:
         research_config=request.options.research_config,
     )
 
-    task = asyncio.create_task(_run_generation_job(job.id, pipeline_request))
-    session_manager.register_task(job.id, task)
-    return GenerateResponse(job_id=job.id, status="started")
+    scheduler = get_scheduler()
+
+    async def _runner() -> None:
+        await _run_generation_job(job.id, pipeline_request)
+
+    try:
+        await scheduler.submit(job.id, _runner)
+    except QueueFull as exc:
+        session_manager.update_job(
+            job.id,
+            status="error",
+            error="Server is busy: too many jobs queued.",
+            message="Server is busy: too many jobs queued.",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+    except SchedulerDraining as exc:
+        session_manager.update_job(
+            job.id,
+            status="error",
+            error="Server is shutting down.",
+            message="Server is shutting down.",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+    return GenerateResponse(job_id=job.id, status="queued")

--- a/backend/api/endpoints/preview.py
+++ b/backend/api/endpoints/preview.py
@@ -8,6 +8,7 @@ from backend.api.schemas import PreviewResponse, PreviewSlide
 from backend.config import settings
 from backend.generator.project_manager import get_svg_files
 from backend.generator.svg_finalize.render_ready import prepare_svg_file_for_render
+from backend.runtime import aoffload, apath_exists, aread_text, aremove
 from backend.session.manager import session_manager
 
 router = APIRouter()
@@ -23,11 +24,12 @@ async def get_critic_history(job_id: str) -> dict:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found.")
 
     critic_path = Path(job.project_dir) / "critic_history.json"
-    if not critic_path.exists():
+    if not await apath_exists(critic_path):
         return {"events": []}
 
     try:
-        data = json.loads(critic_path.read_text(encoding="utf-8"))
+        text = await aread_text(critic_path, encoding="utf-8")
+        data = json.loads(text)
     except (json.JSONDecodeError, OSError):
         return {"events": []}
 
@@ -53,10 +55,10 @@ async def get_critic_archive_svg(job_id: str, filename: str) -> Response:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid filename.")
 
     svg_path = Path(job.project_dir) / "svg_archive" / "repair" / safe_name
-    if not svg_path.exists():
+    if not await apath_exists(svg_path):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Archive not found.")
 
-    content = svg_path.read_text(encoding="utf-8")
+    content = await aread_text(svg_path, encoding="utf-8")
     return Response(content=content, media_type="image/svg+xml")
 
 
@@ -67,7 +69,7 @@ async def get_preview(job_id: str) -> PreviewResponse:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found.")
 
     normalized_status = "complete" if job.output_path and Path(job.output_path).exists() else job.status
-    return _build_preview_response(job_id, Path(job.project_dir) if job.project_dir else None, job.output_path, normalized_status)
+    return await _build_preview_response(job_id, Path(job.project_dir) if job.project_dir else None, job.output_path, normalized_status)
 
 
 @router.get("/preview-project", response_model=PreviewResponse)
@@ -77,7 +79,7 @@ async def get_project_preview(project_dir: str) -> PreviewResponse:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found.")
 
     output_path = _find_latest_output(resolved_project_dir)
-    return _build_preview_response(
+    return await _build_preview_response(
         job_id=resolved_project_dir.name,
         project_dir=resolved_project_dir,
         output_path=str(output_path) if output_path else None,
@@ -85,7 +87,7 @@ async def get_project_preview(project_dir: str) -> PreviewResponse:
     )
 
 
-def _build_preview_response(
+async def _build_preview_response(
     job_id: str,
     project_dir: Path | None,
     output_path: str | None,
@@ -98,11 +100,13 @@ def _build_preview_response(
         slide_files = final_files or output_files
         source = "final" if final_files else "output"
         for index, svg_path in enumerate(slide_files, start=1):
-            prepared_path = prepare_svg_file_for_render(svg_path)
+            # ``prepare_svg_file_for_render`` rewrites href base64 inlines etc.
+            # — synchronous CPU work; offload it.
+            prepared_path = await aoffload(prepare_svg_file_for_render, svg_path)
             try:
-                content = prepared_path.read_text(encoding="utf-8")
+                content = await aread_text(prepared_path, encoding="utf-8")
             finally:
-                prepared_path.unlink(missing_ok=True)
+                await aremove(prepared_path, missing_ok=True)
             slides.append(
                 PreviewSlide(
                     index=index,

--- a/backend/api/endpoints/refine.py
+++ b/backend/api/endpoints/refine.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
 
 from backend.api.schemas import RefineRequest, RefineResponse
+from backend.runtime.scheduler import QueueFull, SchedulerDraining, get_scheduler
 from backend.session.manager import session_manager
 from backend.session.progress import payloads_from_progress_event
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -198,6 +202,38 @@ async def refine_presentation(request: RefineRequest) -> RefineResponse:
         template_id=options.template_id,
     )
 
-    task = asyncio.create_task(_run_refine_job(job.id, pipeline_request))
-    session_manager.register_task(job.id, task)
-    return RefineResponse(job_id=job.id, status="started")
+    scheduler = get_scheduler()
+
+    async def _runner() -> None:
+        await _run_refine_job(job.id, pipeline_request)
+
+    try:
+        # Refines run *after* a successful generate of the same session, so
+        # they get a slight priority boost (lower numeric value) — users
+        # iterating on a result feel snappier than a fresh paper queued at
+        # the same moment.
+        await scheduler.submit(job.id, _runner, priority=5)
+    except QueueFull as exc:
+        session_manager.update_job(
+            job.id,
+            status="error",
+            error="Server is busy: too many jobs queued.",
+            message="Server is busy: too many jobs queued.",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        ) from exc
+    except SchedulerDraining as exc:
+        session_manager.update_job(
+            job.id,
+            status="error",
+            error="Server is shutting down.",
+            message="Server is shutting down.",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+    return RefineResponse(job_id=job.id, status="queued")

--- a/backend/api/endpoints/template_import.py
+++ b/backend/api/endpoints/template_import.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid
 from pathlib import Path
 
@@ -18,6 +19,9 @@ from backend.generator.template_importer import (
     remove_user_template,
 )
 from backend.generator.template_manager import load_template
+from backend.runtime import aensure_dir, aoffload, awrite_bytes
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/templates")
 
@@ -89,18 +93,20 @@ async def upload_template_pptx(file: UploadFile) -> ImportStartResponse:
 
     import_id = uuid.uuid4().hex[:12]
     upload_dir = settings.workspaces_dir / "template_uploads" / import_id
-    upload_dir.mkdir(parents=True, exist_ok=True)
+    await aensure_dir(upload_dir)
     pptx_path = upload_dir / file.filename
-    pptx_path.write_bytes(content)
+    await awrite_bytes(pptx_path, content)
 
-    # Run import in background thread
-    loop = asyncio.get_event_loop()
+    # Run the long-running import on the shared offload pool. We don't
+    # await it — the caller polls /import/{id} for completion.
+    async def _run_import() -> None:
+        try:
+            result = await aoffload(import_pptx_template, pptx_path, task_id=import_id)
+            _import_results[import_id] = result
+        except Exception:  # pragma: no cover — caught for surface visibility
+            logger.exception("template import failed for %s", import_id)
 
-    def _run_import() -> None:
-        result = import_pptx_template(pptx_path, task_id=import_id)
-        _import_results[import_id] = result
-
-    loop.run_in_executor(None, _run_import)
+    asyncio.create_task(_run_import(), name=f"template-import-{import_id}")
 
     return ImportStartResponse(import_id=import_id, status="processing")
 
@@ -172,7 +178,9 @@ async def get_template_preview(template_id: str) -> TemplatePreviewResponse:
     if manifest_path.exists():
         import json
         try:
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            from backend.runtime import aread_text as _aread_text
+            text = await _aread_text(manifest_path, encoding="utf-8")
+            manifest = json.loads(text)
             colors = manifest.get("theme", {}).get("colors", {})
             for key in ("dk1", "lt1", "accent1", "accent2"):
                 val = colors.get(key)

--- a/backend/api/endpoints/upload.py
+++ b/backend/api/endpoints/upload.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, File, HTTPException, UploadFile, status
 
 from backend.api.schemas import FileInfo, UploadResponse
 from backend.config import settings
+from backend.runtime import aensure_dir, awrite_bytes
 from backend.session.manager import session_manager
 
 router = APIRouter()
@@ -59,9 +60,11 @@ async def upload_paper(file: UploadFile = File(...)) -> UploadResponse:
 
     session_id = uuid.uuid4().hex[:12]
     upload_dir = settings.workspaces_dir / "uploads" / session_id
-    upload_dir.mkdir(parents=True, exist_ok=True)
+    await aensure_dir(upload_dir)
     file_path = upload_dir / (file.filename or f"upload{suffix}")
-    file_path.write_bytes(content)
+    # Atomic write through the offload pool — a 64MB upload would otherwise
+    # block the event loop for 50–200ms on slow disks.
+    await awrite_bytes(file_path, content)
 
     session = session_manager.create_session(
         file_path=file_path,

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -60,6 +60,7 @@ class ResearchConfig(BaseModel):
     semantic_scholar_enabled: bool = False
     web_search_enabled: bool = False
     semantic_scholar_api_key: str | None = None
+    web_search_provider: Literal["tavily", "serpapi"] = "tavily"
     tavily_api_key: str | None = None
     serpapi_key: str | None = None
     # Maximum candidates to fetch per source before relevance filtering.

--- a/backend/api/websocket.py
+++ b/backend/api/websocket.py
@@ -13,7 +13,7 @@ Connection lifecycle:
 2. Server immediately sends a ``snapshot`` event reflecting current job
    state, then replays any retained events with ``seq > since_seq``.
 3. Server then streams new events as they arrive.
-4. Server emits ``{"type": "ping", "ts": ...}`` every ``HEARTBEAT_SECONDS``
+4. Server emits ``{"type": "ping", "ts": ...}`` every ``settings.ws_heartbeat_seconds``
    so reverse proxies and browsers don't tear the socket down during long
    silent stages. Clients can ignore pings (or echo them as ``pong``).
 
@@ -27,14 +27,17 @@ import asyncio
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from backend.config import settings
 from backend.session.manager import session_manager
 from backend.session.progress import build_snapshot_event
 
 router = APIRouter()
 
-# Send a heartbeat at most this often. 20s comfortably beats nginx's
-# 60s default proxy_read_timeout and keeps Cloudflare-style proxies happy.
-HEARTBEAT_SECONDS = 20.0
+# Heartbeat interval is configurable so reverse-proxy timeouts can be tuned
+# from the environment. Default 15s comfortably beats nginx's 60s default
+# ``proxy_read_timeout`` and keeps Cloudflare-style proxies happy.
+def _heartbeat_seconds() -> float:
+    return float(max(1, settings.ws_heartbeat_seconds))
 
 TERMINAL_STATUSES = {"complete", "error", "cancelled"}
 
@@ -134,7 +137,7 @@ async def _next_event_or_heartbeat(
     caller should keep waiting.
     """
     try:
-        return await asyncio.wait_for(queue.get(), timeout=HEARTBEAT_SECONDS)
+        return await asyncio.wait_for(queue.get(), timeout=_heartbeat_seconds())
     except asyncio.TimeoutError:
         await websocket.send_json({
             "type": "ping",

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
@@ -71,6 +72,28 @@ def create_app() -> FastAPI:
     @app.get("/healthz")
     async def healthcheck() -> dict[str, str]:
         return {"status": "ok"}
+
+    @app.get("/healthz/runtime")
+    async def runtime_healthcheck() -> dict:
+        from backend.runtime.offload import offload_stats
+        from backend.runtime.scheduler import get_scheduler
+
+        tasks = []
+        current = asyncio.current_task()
+        for task in asyncio.all_tasks():
+            if task is current:
+                continue
+            tasks.append({
+                "name": task.get_name(),
+                "done": task.done(),
+                "cancelled": task.cancelled(),
+            })
+        return {
+            "status": "ok",
+            "scheduler": get_scheduler().diagnostics(),
+            "offload": offload_stats(),
+            "tasks": tasks,
+        }
 
     @app.get("/")
     async def root() -> dict[str, str]:

--- a/backend/app.py
+++ b/backend/app.py
@@ -2,12 +2,52 @@
 
 from __future__ import annotations
 
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.api.router import api_router
 from backend.api.websocket import router as websocket_router
 from backend.config import settings
+from backend.runtime.offload import init_offload, shutdown_offload
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Application lifespan: bring up the runtime pool, scheduler, event bus.
+
+    The order matters:
+
+      1. ``init_offload`` first — every async helper above relies on the pool.
+      2. Scheduler / EventBus next; they pull events through the pool.
+      3. On shutdown we drain the scheduler so in-flight jobs get a chance
+         to flush their final ``error: cancelled`` event before sockets close,
+         then tear down the pool last.
+    """
+    init_offload(settings.io_pool_workers)
+    try:
+        # Scheduler / EventBus are wired in here once their modules land
+        # (kept opt-in so the import graph stays clean during the rollout).
+        try:
+            from backend.runtime.scheduler import get_scheduler
+            scheduler = get_scheduler()
+            await scheduler.start()
+            logger.info("scheduler started")
+        except ImportError:
+            scheduler = None
+
+        try:
+            yield
+        finally:
+            if scheduler is not None:
+                await scheduler.shutdown(timeout=30.0)
+    finally:
+        shutdown_offload()
 
 
 def create_app() -> FastAPI:
@@ -15,6 +55,7 @@ def create_app() -> FastAPI:
         title="Paper PPT Agent",
         version="0.1.0",
         description="Generate editable PowerPoint presentations from academic paper PDFs or TeX source packages.",
+        lifespan=lifespan,
     )
     app.add_middleware(
         CORSMiddleware,

--- a/backend/config.py
+++ b/backend/config.py
@@ -89,8 +89,36 @@ class Settings(BaseSettings):
     references_dir: Path = PROJECT_ROOT / "assets" / "references"
 
     # Limits
-    max_concurrent_jobs: int = 3
+    max_concurrent_jobs: int = 2
     max_upload_bytes: int = 64 * 1024 * 1024  # 64 MB per uploaded paper
+
+    # ── Async runtime ────────────────────────────────────────────────────
+    # Size of the global ThreadPoolExecutor used by ``runtime.aoffload``.
+    # All blocking file IO and CPU-bound library calls (fitz, python-pptx,
+    # cairosvg, PIL) flow through this pool, so size it for IO concurrency
+    # rather than core count.
+    io_pool_workers: int = 16
+
+    # ── Job scheduling ───────────────────────────────────────────────────
+    # Backlog cap for queued jobs; a 16th queued job returns 429.
+    job_queue_capacity: int = 16
+
+    # ── External tool timeouts (seconds) ─────────────────────────────────
+    pandoc_timeout: int = 60
+    pdflatex_timeout: int = 90
+    cairosvg_timeout: int = 30
+    # Number of parallel equation renders allowed in flight.
+    equation_render_concurrency: int = 4
+
+    # ── WebSocket ────────────────────────────────────────────────────────
+    ws_subscriber_queue_size: int = 1024
+    ws_heartbeat_seconds: int = 15
+
+    # ── Persistence ──────────────────────────────────────────────────────
+    # Debounce window (ms) for full session_state.json snapshots. Events
+    # always go to the per-job NDJSON stream synchronously so nothing is
+    # lost on a hard crash; the snapshot just rolls up indices.
+    persist_debounce_ms: int = 200
 
 
 settings = Settings()

--- a/backend/config.py
+++ b/backend/config.py
@@ -89,7 +89,9 @@ class Settings(BaseSettings):
     references_dir: Path = PROJECT_ROOT / "assets" / "references"
 
     # Limits
-    max_concurrent_jobs: int = 2
+    # Historical compatibility knob. Job scheduling is now immediate and
+    # per-job; this no longer caps generate/refine submissions.
+    max_concurrent_jobs: int = 1
     max_upload_bytes: int = 64 * 1024 * 1024  # 64 MB per uploaded paper
 
     # ── Async runtime ────────────────────────────────────────────────────

--- a/backend/orchestrator/pipeline.py
+++ b/backend/orchestrator/pipeline.py
@@ -16,6 +16,7 @@ from typing import Literal
 from backend.config import settings
 from backend.api.schemas import ResearchConfig
 from backend.generator.svg_critic import CriticReport
+from backend.runtime import aoffload, aread_text, awrite_text
 from backend.usage.tracker import reset_usage_context, set_usage_context
 
 from .manuscript import count_manuscript_pages
@@ -77,19 +78,23 @@ def _querying_enrichment_payload(config: ResearchConfig) -> dict:
     return payload
 
 
-def _write_enrichment_debug(project_dir: Path, ctx: ResearchContext, stats) -> None:
+async def _write_enrichment_debug(
+    project_dir: Path, ctx: ResearchContext, stats
+) -> None:
     debug_dir = project_dir / "debug"
     try:
-        debug_dir.mkdir(parents=True, exist_ok=True)
+        await aoffload(debug_dir.mkdir, parents=True, exist_ok=True)
         payload = stats.to_dict()
         payload["queries_used"] = list(ctx.queries_used)
-        (debug_dir / "research_enrichment_stats.json").write_text(
+        await awrite_text(
+            debug_dir / "research_enrichment_stats.json",
             json.dumps(payload, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
         block = ctx.enrichment_block_for_pass1()
         if block:
-            (debug_dir / "research_enrichment_pass1_block.md").write_text(
+            await awrite_text(
+                debug_dir / "research_enrichment_pass1_block.md",
                 block,
                 encoding="utf-8",
             )
@@ -239,7 +244,7 @@ async def run_pipeline(
                 paper_abstract=paper.abstract,
                 config=research_cfg,
             )
-            _write_enrichment_debug(project_dir, research_ctx, stats)
+            await _write_enrichment_debug(project_dir, research_ctx, stats)
             yield ProgressEvent(
                 "research",
                 "progress",
@@ -299,7 +304,7 @@ async def run_pipeline(
         manuscript = analysis_task.result()
 
         # Save manuscript and deep analysis artifacts
-        (project_dir / "manuscript.md").write_text(manuscript, encoding="utf-8")
+        await awrite_text(project_dir / "manuscript.md", manuscript, encoding="utf-8")
         yield ProgressEvent(
             "research",
             "complete",
@@ -354,7 +359,7 @@ async def run_pipeline(
         )
 
         # Save design spec
-        (project_dir / "design_spec.md").write_text(design_spec, encoding="utf-8")
+        await awrite_text(project_dir / "design_spec.md", design_spec, encoding="utf-8")
         yield ProgressEvent("strategy", "complete", "Design spec created", 0.40)
 
         # Stage 4: SVG executor
@@ -449,12 +454,16 @@ async def run_pipeline(
             data={"critic": critic_events},
         )
 
-        _save_critic_history(project_dir, critic_events)
+        await _save_critic_history(project_dir, critic_events)
 
         # Stage 5: Post-processing
         set_usage_context(stage="postprocess")
         yield ProgressEvent("postprocess", "started", "Finalizing SVGs...")
-        stats = finalize_project(project_dir)
+        # finalize_project walks every SVG, runs cairosvg / PIL / regex
+        # rewrites: minutes of synchronous CPU work. Push it to the offload
+        # pool so heartbeats, the WS event bus, and the scheduler dispatcher
+        # all keep ticking.
+        stats = await aoffload(finalize_project, project_dir)
         yield ProgressEvent(
             "postprocess",
             "complete",
@@ -471,7 +480,8 @@ async def run_pipeline(
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         pptx_path = project_dir / "exports" / f"presentation_{timestamp}.pptx"
 
-        create_pptx(
+        await aoffload(
+            create_pptx,
             svg_files,
             pptx_path,
             canvas_format=request.canvas_format,
@@ -493,7 +503,7 @@ async def run_pipeline(
         reset_usage_context(usage_snapshot)
 
 
-def _load_figure_inventory(project_dir: Path) -> list[dict]:
+async def _load_figure_inventory(project_dir: Path) -> list[dict]:
     """Read figure_review.json from a refine workspace.
 
     The refine pipeline runs without re-parsing the PDF, so we cannot call
@@ -501,12 +511,12 @@ def _load_figure_inventory(project_dir: Path) -> list[dict]:
     is written once during the original parse and contains everything the
     executor needs to resolve `[[FIG:id]]` tokens to real hrefs.
     """
-    import json
     candidate = project_dir / "sources" / "images" / "figure_review.json"
     if not candidate.exists():
         return []
     try:
-        records = json.loads(candidate.read_text(encoding="utf-8"))
+        text = await aread_text(candidate, encoding="utf-8")
+        records = json.loads(text)
     except (OSError, ValueError):
         return []
     inventory: list[dict] = []
@@ -637,8 +647,8 @@ async def run_refine_pipeline(
         )
         return
 
-    manuscript = manuscript_path.read_text(encoding="utf-8")
-    design_spec = design_spec_path.read_text(encoding="utf-8")
+    manuscript = await aread_text(manuscript_path, encoding="utf-8")
+    design_spec = await aread_text(design_spec_path, encoding="utf-8")
 
     provider_kwargs = {"base_url": request.base_url}
     if request.deepseek_settings is not None:
@@ -678,11 +688,11 @@ async def run_refine_pipeline(
             target_pages=target_pages,
             allow_structure_changes=True,
         )
-        manuscript_path.write_text(manuscript, encoding="utf-8")
+        await awrite_text(manuscript_path, manuscript, encoding="utf-8")
         yield ProgressEvent("research", "complete", "Manuscript revised", 0.15)
 
         yield ProgressEvent("strategy", "started", "Rebuilding design specification...", 0.15)
-        refine_figure_inventory = _load_figure_inventory(project_dir)
+        refine_figure_inventory = await _load_figure_inventory(project_dir)
         design_spec = await strategist_agent.create_design_spec(
             manuscript,
             llm,
@@ -698,7 +708,7 @@ async def run_refine_pipeline(
             gemini_api_key=request.gemini_api_key,
             figure_inventory=refine_figure_inventory,
         )
-        design_spec_path.write_text(design_spec, encoding="utf-8")
+        await awrite_text(design_spec_path, design_spec, encoding="utf-8")
         yield ProgressEvent("strategy", "complete", "Design spec rebuilt", 0.30)
 
     # Archive current svg_output before overwriting
@@ -739,7 +749,7 @@ async def run_refine_pipeline(
             entry["archive_path"] = archive_path
         refine_critic_events.append(entry)
 
-    refine_inventory = _load_figure_inventory(project_dir)
+    refine_inventory = await _load_figure_inventory(project_dir)
 
     # Load template context for refine if specified
     refine_template_ctx = ""
@@ -795,7 +805,7 @@ async def run_refine_pipeline(
     postprocess_start = generation_start + generation_span
     export_start = 0.80 if request.allow_structure_changes else 0.80
     yield ProgressEvent("postprocess", "started", "Finalizing SVGs...", postprocess_start)
-    stats = finalize_project(project_dir)
+    stats = await aoffload(finalize_project, project_dir)
     yield ProgressEvent(
         "postprocess", "complete",
         f"Processed {stats['total_files']} files",
@@ -810,11 +820,17 @@ async def run_refine_pipeline(
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     pptx_path = project_dir / "exports" / f"presentation_{timestamp}.pptx"
 
-    create_pptx(svg_files, pptx_path, canvas_format=request.canvas_format, notes=notes)
+    await aoffload(
+        create_pptx,
+        svg_files,
+        pptx_path,
+        canvas_format=request.canvas_format,
+        notes=notes,
+    )
 
     # Persist feedback history to disk for auditability
-    _save_feedback_history(project_dir, request.feedback_history)
-    _save_critic_history(project_dir, refine_critic_events, refine=True)
+    await _save_feedback_history(project_dir, request.feedback_history)
+    await _save_critic_history(project_dir, refine_critic_events, refine=True)
 
     yield ProgressEvent(
         "export", "complete",
@@ -931,29 +947,29 @@ def _build_style_overrides_block(overrides: dict | None) -> str:
     return "## Style Overrides (must follow)\n" + "\n".join(parts)
 
 
-def _save_feedback_history(project_dir: Path, history: list[str]) -> None:
+async def _save_feedback_history(project_dir: Path, history: list[str]) -> None:
     """Append-write feedback_history.json for auditability."""
-    import json
-
     path = project_dir / "feedback_history.json"
-    path.write_text(json.dumps(history, ensure_ascii=False, indent=2), encoding="utf-8")
+    await awrite_text(
+        path,
+        json.dumps(history, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
 
 
-def _save_critic_history(
+async def _save_critic_history(
     project_dir: Path,
     critic_events: list[dict],
     *,
     refine: bool = False,
 ) -> None:
     """Persist critic events to critic_history.json for post-run analysis."""
-    import json
-    from datetime import datetime
-
     path = project_dir / "critic_history.json"
     existing: dict = {}
     if path.exists():
         try:
-            existing = json.loads(path.read_text(encoding="utf-8"))
+            text = await aread_text(path, encoding="utf-8")
+            existing = json.loads(text)
         except (json.JSONDecodeError, OSError):
             existing = {}
 
@@ -963,7 +979,11 @@ def _save_critic_history(
     if "created_at" not in existing:
         existing["created_at"] = existing["updated_at"]
 
-    path.write_text(json.dumps(existing, ensure_ascii=False, indent=2), encoding="utf-8")
+    await awrite_text(
+        path,
+        json.dumps(existing, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
 
 
 def _seed_svg_output_for_targeted_refine(project_dir: Path, target_pages: list[int]) -> None:

--- a/backend/orchestrator/research_enrichment.py
+++ b/backend/orchestrator/research_enrichment.py
@@ -257,8 +257,13 @@ async def _enrich_web_search(
 
     tavily_key = (config.tavily_api_key or "").strip()
     serpapi_key = (config.serpapi_key or "").strip()
+    provider = getattr(config, "web_search_provider", "tavily") or "tavily"
 
-    if not tavily_key and not serpapi_key:
+    if provider == "tavily" and not tavily_key:
+        stats.web_error = "no_api_key"
+        ctx.queries_used.append("web: <skipped: no api key>")
+        return
+    if provider == "serpapi" and not serpapi_key:
         stats.web_error = "no_api_key"
         ctx.queries_used.append("web: <skipped: no api key>")
         return
@@ -271,7 +276,7 @@ async def _enrich_web_search(
     try:
         import httpx  # type: ignore[import-not-found]
 
-        if tavily_key:
+        if provider == "tavily":
             stats.web_provider = "tavily"
             results = await _tavily_search(httpx, query, tavily_key, config.max_results_per_source)
         else:

--- a/backend/orchestrator/strategist_agent.py
+++ b/backend/orchestrator/strategist_agent.py
@@ -113,9 +113,14 @@ async def _retrieve_icon_candidates(
             logger.warning("Icon search timed out or was cancelled for query: %s", query)
             break
         for r in results:
-            if r["path"] not in seen_paths:
-                seen_paths.add(r["path"])
-                candidates.append(r)
+            path = str(r.get("path") or "")
+            if path in seen_paths:
+                continue
+            if not _icon_asset_exists(path):
+                logger.warning("Skipping stale icon RAG candidate with missing local asset: %s", path)
+                continue
+            seen_paths.add(path)
+            candidates.append(r)
 
     # Sort by score descending, take top N
     candidates.sort(key=lambda x: x["score"], reverse=True)

--- a/backend/parser/equation_renderer.py
+++ b/backend/parser/equation_renderer.py
@@ -1,15 +1,36 @@
 """LaTeX equation rendering to images.
 
 Converts LaTeX math expressions to PNG images for embedding in SVG slides.
-Uses matplotlib as the rendering backend (available via numpy/matplotlib).
+Uses matplotlib as the rendering backend.
+
+Concurrency contract: matplotlib's ``Agg`` backend is *not* thread-safe at
+the global pyplot level — concurrent ``plt.subplots`` / ``fig.savefig``
+calls from different threads will scramble each other's state. We funnel
+every render through a process-wide ``asyncio.Semaphore`` so at most
+``settings.equation_render_concurrency`` renders are in flight; each one
+runs on the offload pool but they execute one-at-a-time inside a single
+``aoffload`` slot so matplotlib stays consistent.
 """
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
-import subprocess
-import shutil
 from pathlib import Path
+
+from backend.config import settings
+from backend.runtime import aoffload
+
+# Module-level semaphore — created lazily on the running loop so this
+# module can be imported before the loop exists (e.g. at app startup).
+_render_sem: asyncio.Semaphore | None = None
+
+
+def _get_sem() -> asyncio.Semaphore:
+    global _render_sem
+    if _render_sem is None:
+        _render_sem = asyncio.Semaphore(max(1, settings.equation_render_concurrency))
+    return _render_sem
 
 
 async def render_equation(
@@ -29,20 +50,18 @@ async def render_equation(
     """
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Generate deterministic filename from equation content
     eq_hash = hashlib.md5(latex.encode()).hexdigest()[:12]
     output_path = output_dir / f"eq_{eq_hash}.png"
 
     if output_path.exists():
         return output_path
 
-    # Try matplotlib rendering (most reliable cross-platform)
-    try:
-        return _render_with_matplotlib(latex, output_path, dpi)
-    except Exception:
-        pass
-
-    return None
+    sem = _get_sem()
+    async with sem:
+        try:
+            return await aoffload(_render_with_matplotlib, latex, output_path, dpi)
+        except Exception:
+            return None
 
 
 def _render_with_matplotlib(latex: str, output_path: Path, dpi: int) -> Path:
@@ -55,8 +74,7 @@ def _render_with_matplotlib(latex: str, output_path: Path, dpi: int) -> Path:
     fig, ax = plt.subplots(figsize=(0.01, 0.01))
     ax.axis("off")
 
-    # Render the equation
-    text = ax.text(
+    ax.text(
         0.5,
         0.5,
         f"${latex}$",
@@ -66,7 +84,6 @@ def _render_with_matplotlib(latex: str, output_path: Path, dpi: int) -> Path:
         horizontalalignment="center",
     )
 
-    # Auto-fit figure to text
     fig.savefig(
         str(output_path),
         dpi=dpi,

--- a/backend/parser/latex_parser.py
+++ b/backend/parser/latex_parser.py
@@ -7,16 +7,21 @@ for \input/\include resolution and bibliography extraction.
 
 from __future__ import annotations
 
+import logging
 import re
 import shutil
-import subprocess
-import tempfile
 import tarfile
 import zipfile
 from pathlib import Path
 
+from backend.config import settings
+from backend.runtime import aoffload, arun
+from backend.runtime.subproc import SubprocessError, SubprocessTimeout
+
 from .base import PaperParser
 from .paper_model import PaperFigure, PaperSection, ParsedPaper
+
+logger = logging.getLogger(__name__)
 
 
 def _probe_image_size(path: Path) -> tuple[int, int]:
@@ -56,10 +61,12 @@ class LaTeXParser(PaperParser):
         extract_dir = output_dir / "latex_src"
         extract_dir.mkdir(exist_ok=True)
 
-        with zipfile.ZipFile(zip_path, "r") as zf:
-            self._extract_zip_safely(zf, extract_dir)
+        # Decompression is fully synchronous and can take seconds on a large
+        # arXiv tarball — run it on the offload pool so the event loop is
+        # free to keep serving other requests.
+        await aoffload(self._extract_zip_to_dir, zip_path, extract_dir)
 
-        main_tex = self._find_main_tex(extract_dir)
+        main_tex = await aoffload(self._find_main_tex, extract_dir)
         if not main_tex:
             raise ValueError(f"No main .tex file found in {zip_path}")
 
@@ -72,14 +79,21 @@ class LaTeXParser(PaperParser):
         extract_dir = output_dir / "latex_src"
         extract_dir.mkdir(exist_ok=True)
 
-        with tarfile.open(tar_path, "r:*") as tf:
-            self._extract_tar_safely(tf, extract_dir)
+        await aoffload(self._extract_tar_to_dir, tar_path, extract_dir)
 
-        main_tex = self._find_main_tex(extract_dir)
+        main_tex = await aoffload(self._find_main_tex, extract_dir)
         if not main_tex:
             raise ValueError(f"No main .tex file found in {tar_path}")
 
         return await self._parse_tex(main_tex, output_dir, images_dir)
+
+    def _extract_zip_to_dir(self, zip_path: Path, extract_dir: Path) -> None:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            self._extract_zip_safely(zf, extract_dir)
+
+    def _extract_tar_to_dir(self, tar_path: Path, extract_dir: Path) -> None:
+        with tarfile.open(tar_path, "r:*") as tf:
+            self._extract_tar_safely(tf, extract_dir)
 
     def _find_main_tex(self, directory: Path) -> Path | None:
         """Find the main .tex file by looking for \\documentclass."""
@@ -100,25 +114,24 @@ class LaTeXParser(PaperParser):
         r"""Parse a single .tex file with \input resolution."""
         tex_dir = tex_path.parent
 
-        # Resolve \input and \include directives
-        resolved_content = self._resolve_includes(tex_path, tex_dir)
+        # The metadata / figure / section extraction is all synchronous regex
+        # work — push it to the offload pool. Pandoc invocation is split out
+        # so it can run as an async subprocess (real OS-level parallelism).
+        resolved_content = await aoffload(self._resolve_includes, tex_path, tex_dir)
 
-        # Extract metadata before pandoc conversion
-        title = self._extract_title(resolved_content)
-        authors = self._extract_authors(resolved_content)
-        abstract = self._extract_abstract(resolved_content)
+        title = await aoffload(self._extract_title, resolved_content)
+        authors = await aoffload(self._extract_authors, resolved_content)
+        abstract = await aoffload(self._extract_abstract, resolved_content)
+        figures = await aoffload(
+            self._extract_figures, resolved_content, tex_dir, images_dir
+        )
 
-        # Extract figure references and copy images
-        figures = self._extract_figures(resolved_content, tex_dir, images_dir)
+        markdown = await self._convert_to_markdown_async(
+            resolved_content, tex_dir, output_dir
+        )
 
-        # Convert to Markdown
-        markdown = self._convert_to_markdown(resolved_content, tex_dir, output_dir)
-
-        # Parse sections from Markdown
-        sections = self._parse_sections(markdown, figures)
-
-        # Extract references
-        references = self._extract_references(resolved_content, tex_dir)
+        sections = await aoffload(self._parse_sections, markdown, figures)
+        references = await aoffload(self._extract_references, resolved_content, tex_dir)
 
         return ParsedPaper(
             title=title,
@@ -318,20 +331,23 @@ class LaTeXParser(PaperParser):
             return None
         return target
 
-    def _convert_to_markdown(
+    async def _convert_to_markdown_async(
         self, content: str, tex_dir: Path, output_dir: Path
     ) -> str:
-        """Convert LaTeX content to Markdown using pandoc."""
-        if not shutil.which("pandoc"):
-            # Fallback: strip LaTeX commands manually
-            return self._basic_latex_to_markdown(content)
+        """Convert LaTeX content to Markdown using pandoc (async subprocess).
 
-        # Write resolved content to a temp file
+        Falls back to a regex-based stub when pandoc is not on PATH or when
+        it errors out. Timeout / non-zero exit are handled separately so the
+        caller can still surface the failure mode in logs.
+        """
+        if not shutil.which("pandoc"):
+            return await aoffload(self._basic_latex_to_markdown, content)
+
         tmp_tex = output_dir / "_resolved.tex"
-        tmp_tex.write_text(content, encoding="utf-8")
+        await aoffload(tmp_tex.write_text, content, encoding="utf-8")
 
         try:
-            result = subprocess.run(
+            cp = await arun(
                 [
                     "pandoc",
                     "-f", "latex",
@@ -339,20 +355,27 @@ class LaTeXParser(PaperParser):
                     "--wrap=none",
                     str(tmp_tex),
                 ],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=60,
-                cwd=str(tex_dir),
+                timeout=float(settings.pandoc_timeout),
+                cwd=tex_dir,
+                check=False,
             )
-            if result.returncode == 0:
-                return result.stdout
-            return self._basic_latex_to_markdown(content)
+            if cp.returncode == 0:
+                return cp.stdout
+            logger.warning(
+                "pandoc latex→md failed (rc=%d): %s",
+                cp.returncode,
+                cp.stderr.strip()[:300],
+            )
+        except SubprocessTimeout:
+            logger.warning("pandoc latex→md timed out after %ss", settings.pandoc_timeout)
+        except SubprocessError as exc:
+            logger.warning("pandoc latex→md error: %s", exc)
         except Exception:
-            return self._basic_latex_to_markdown(content)
+            logger.exception("pandoc latex→md unexpected error")
         finally:
-            tmp_tex.unlink(missing_ok=True)
+            await aoffload(tmp_tex.unlink, missing_ok=True)
+
+        return await aoffload(self._basic_latex_to_markdown, content)
 
     def _basic_latex_to_markdown(self, content: str) -> str:
         """Basic LaTeX to Markdown conversion without pandoc."""

--- a/backend/parser/pdf_parser.py
+++ b/backend/parser/pdf_parser.py
@@ -58,6 +58,8 @@ try:  # pragma: no cover - defensive, API surface differs across versions
 except Exception:
     pass
 
+from backend.runtime import aoffload
+
 from .base import PaperParser
 from .paper_model import PaperFigure, PaperSection, PaperTable, ParsedPaper
 
@@ -90,6 +92,13 @@ class PDFParser(PaperParser):
     last_parse_info: dict[str, object] = {}
 
     async def parse(self, file_path: Path, output_dir: Path) -> ParsedPaper:
+        # The whole parse is CPU/IO heavy (fitz C calls, DPI rasterization,
+        # pymupdf4llm layout analysis). Run it on the offload pool so the
+        # event loop stays responsive — other HTTP requests, websocket
+        # frames, the scheduler dispatcher all keep running.
+        return await aoffload(self._parse_sync, file_path, output_dir)
+
+    def _parse_sync(self, file_path: Path, output_dir: Path) -> ParsedPaper:
         output_dir.mkdir(parents=True, exist_ok=True)
         images_dir = output_dir / "images"
         images_dir.mkdir(exist_ok=True)

--- a/backend/runtime/__init__.py
+++ b/backend/runtime/__init__.py
@@ -16,7 +16,7 @@ Public surface:
     Scheduler / EventBus                   — job dispatch and event fanout
 """
 
-from .offload import aoffload, init_offload, shutdown_offload
+from .offload import aoffload, init_offload, offload_stats, shutdown_offload
 from .subproc import SubprocessError, SubprocessTimeout, arun
 from .io import (
     aread_text,
@@ -31,6 +31,7 @@ from .io import (
 __all__ = [
     "aoffload",
     "init_offload",
+    "offload_stats",
     "shutdown_offload",
     "arun",
     "SubprocessError",

--- a/backend/runtime/__init__.py
+++ b/backend/runtime/__init__.py
@@ -1,0 +1,45 @@
+"""Async runtime primitives.
+
+This package centralizes everything that bridges sync world (file IO,
+subprocesses, CPU-bound libraries like fitz / python-pptx) into the asyncio
+event loop. The single rule of the codebase is:
+
+    No async function may call sync IO, subprocess, or fitz/PIL/python-pptx
+    directly. Always go through ``aoffload`` / ``arun`` / the helpers in
+    ``runtime.io``.
+
+Public surface:
+
+    aoffload(fn, *args, **kw)              — run a sync callable on the IO pool
+    arun(argv, *, timeout, ...)            — async subprocess with hard timeout + SIGKILL
+    aread_text / awrite_text / ...         — async file IO helpers
+    Scheduler / EventBus                   — job dispatch and event fanout
+"""
+
+from .offload import aoffload, init_offload, shutdown_offload
+from .subproc import SubprocessError, SubprocessTimeout, arun
+from .io import (
+    aread_text,
+    awrite_text,
+    aread_bytes,
+    awrite_bytes,
+    aensure_dir,
+    apath_exists,
+    aremove,
+)
+
+__all__ = [
+    "aoffload",
+    "init_offload",
+    "shutdown_offload",
+    "arun",
+    "SubprocessError",
+    "SubprocessTimeout",
+    "aread_text",
+    "awrite_text",
+    "aread_bytes",
+    "awrite_bytes",
+    "aensure_dir",
+    "apath_exists",
+    "aremove",
+]

--- a/backend/runtime/event_bus.py
+++ b/backend/runtime/event_bus.py
@@ -1,0 +1,147 @@
+"""Per-job event fan-out with bounded queues and a server-driven heartbeat.
+
+This is the live event channel used by the websocket endpoint. It does not
+own durability — committed events live in ``SessionManager`` (in-memory ring
++ NDJSON disk log). The bus only buffers events for connected subscribers
+and exposes an ``async for`` interface that yields:
+
+    * ``replay`` events that arrived while the subscriber was disconnected
+      (delivered first, drained from the SessionManager ring);
+    * ``live`` events as they are published;
+    * synthetic ``heartbeat`` frames every ``ws_heartbeat_seconds`` so
+      proxies don't kill idle WebSocket connections;
+    * synthetic ``degraded`` frames when the per-subscriber queue overflows
+      (the client can surface "network congestion, frames dropped").
+
+Bounded queue + drop-oldest is intentional: we'd rather show the user the
+*latest* progress than freeze the producer because one slow client can't
+keep up. The ``dropped`` count is reported back so the UI can display it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+from backend.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class _Subscriber:
+    __slots__ = ("queue", "dropped", "buffer")
+
+    def __init__(self, capacity: int) -> None:
+        self.queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=capacity)
+        self.dropped: int = 0
+        # Mirror of last frame to coalesce the next ``degraded`` notice.
+        self.buffer: deque[dict[str, Any]] = deque(maxlen=1)
+
+    def offer(self, event: dict[str, Any]) -> None:
+        """Non-blocking publish. Drops the *oldest* live frame on overflow.
+
+        Heartbeat / degraded frames are never themselves dropped; they're
+        cheap and the client uses them for liveness signaling.
+        """
+        try:
+            self.queue.put_nowait(event)
+        except asyncio.QueueFull:
+            try:
+                self.queue.get_nowait()
+            except asyncio.QueueEmpty:  # pragma: no cover
+                pass
+            self.dropped += 1
+            try:
+                self.queue.put_nowait(event)
+            except asyncio.QueueFull:  # pragma: no cover
+                pass
+
+
+class EventBus:
+    """In-memory fan-out for live job events.
+
+    Singleton-style: one bus per process, accessed via ``get_event_bus``.
+    Decoupled from ``SessionManager`` so the persistence layer can evolve
+    independently of the transport.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: dict[str, list[_Subscriber]] = {}
+        self._lock = asyncio.Lock()
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._stopped = False
+
+    async def start(self) -> None:
+        if self._heartbeat_task is None or self._heartbeat_task.done():
+            self._heartbeat_task = asyncio.create_task(
+                self._heartbeat_loop(), name="event-bus-heartbeat"
+            )
+
+    async def stop(self) -> None:
+        self._stopped = True
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._heartbeat_task = None
+
+    async def publish(self, job_id: str, event: dict[str, Any]) -> None:
+        """Push an event to every subscriber of *job_id*."""
+        subs = self._subscribers.get(job_id)
+        if not subs:
+            return
+        for sub in subs:
+            sub.offer(event)
+            if sub.dropped and sub.dropped % 8 == 1:
+                sub.offer(
+                    {
+                        "type": "degraded",
+                        "job_id": job_id,
+                        "dropped": sub.dropped,
+                        "ts": time.time(),
+                    }
+                )
+
+    @asynccontextmanager
+    async def subscribe(self, job_id: str) -> AsyncIterator[_Subscriber]:
+        sub = _Subscriber(capacity=settings.ws_subscriber_queue_size)
+        async with self._lock:
+            self._subscribers.setdefault(job_id, []).append(sub)
+        try:
+            yield sub
+        finally:
+            async with self._lock:
+                bucket = self._subscribers.get(job_id)
+                if bucket:
+                    self._subscribers[job_id] = [s for s in bucket if s is not sub]
+                    if not self._subscribers[job_id]:
+                        self._subscribers.pop(job_id, None)
+
+    async def _heartbeat_loop(self) -> None:
+        interval = max(1, int(settings.ws_heartbeat_seconds))
+        while not self._stopped:
+            try:
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                return
+            now = time.time()
+            for job_id, subs in list(self._subscribers.items()):
+                frame = {"type": "heartbeat", "job_id": job_id, "ts": now}
+                for sub in subs:
+                    sub.offer(frame)
+
+
+_bus: EventBus | None = None
+
+
+def get_event_bus() -> EventBus:
+    global _bus
+    if _bus is None:
+        _bus = EventBus()
+    return _bus

--- a/backend/runtime/io.py
+++ b/backend/runtime/io.py
@@ -1,0 +1,89 @@
+"""Async file IO helpers built on top of ``aoffload``.
+
+These wrap the few sync filesystem patterns the pipeline uses (read/write
+text, read/write bytes, mkdir, exists, remove) so callers can ``await`` them
+without thinking about the executor. ``awrite_text`` / ``awrite_bytes`` use
+an atomic ``tmp + replace`` so a process crash mid-write never leaves a
+half-written ``manuscript.md`` or state JSON.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Union
+
+from .offload import aoffload
+
+PathLike = Union[str, Path]
+
+
+def _read_text(path: PathLike, encoding: str, errors: str) -> str:
+    return Path(path).read_text(encoding=encoding, errors=errors)
+
+
+def _write_text_atomic(path: PathLike, data: str, encoding: str) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(data, encoding=encoding)
+    os.replace(tmp, p)
+
+
+def _read_bytes(path: PathLike) -> bytes:
+    return Path(path).read_bytes()
+
+
+def _write_bytes_atomic(path: PathLike, data: bytes) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_bytes(data)
+    os.replace(tmp, p)
+
+
+def _ensure_dir(path: PathLike) -> None:
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def _exists(path: PathLike) -> bool:
+    return Path(path).exists()
+
+
+def _remove(path: PathLike, missing_ok: bool) -> None:
+    p = Path(path)
+    try:
+        p.unlink()
+    except FileNotFoundError:
+        if not missing_ok:
+            raise
+
+
+async def aread_text(
+    path: PathLike, encoding: str = "utf-8", errors: str = "strict"
+) -> str:
+    return await aoffload(_read_text, path, encoding, errors)
+
+
+async def awrite_text(path: PathLike, data: str, encoding: str = "utf-8") -> None:
+    await aoffload(_write_text_atomic, path, data, encoding)
+
+
+async def aread_bytes(path: PathLike) -> bytes:
+    return await aoffload(_read_bytes, path)
+
+
+async def awrite_bytes(path: PathLike, data: bytes) -> None:
+    await aoffload(_write_bytes_atomic, path, data)
+
+
+async def aensure_dir(path: PathLike) -> None:
+    await aoffload(_ensure_dir, path)
+
+
+async def apath_exists(path: PathLike) -> bool:
+    return await aoffload(_exists, path)
+
+
+async def aremove(path: PathLike, *, missing_ok: bool = True) -> None:
+    await aoffload(_remove, path, missing_ok)

--- a/backend/runtime/offload.py
+++ b/backend/runtime/offload.py
@@ -52,6 +52,27 @@ def shutdown_offload(wait: bool = True) -> None:
     logger.info("offload pool stopped")
 
 
+def offload_stats() -> dict[str, int | bool | None]:
+    """Best-effort diagnostics for the global offload executor."""
+    pool = _pool
+    if pool is None:
+        return {
+            "started": False,
+            "max_workers": None,
+            "queued": None,
+            "threads": None,
+        }
+    queue = getattr(pool, "_work_queue", None)
+    threads = getattr(pool, "_threads", None)
+    queued = queue.qsize() if queue is not None and hasattr(queue, "qsize") else None
+    return {
+        "started": True,
+        "max_workers": getattr(pool, "_max_workers", None),
+        "queued": queued,
+        "threads": len(threads) if threads is not None else None,
+    }
+
+
 async def aoffload(fn: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
     """Run a sync callable on the global offload pool.
 

--- a/backend/runtime/offload.py
+++ b/backend/runtime/offload.py
@@ -1,0 +1,68 @@
+"""Single global ThreadPoolExecutor for offloading sync work.
+
+The event loop runs on a single thread; any blocking call (file IO, fitz,
+subprocess.run, python-pptx, PIL, cairosvg) must be pushed here so other
+coroutines (HTTP handlers, websocket frames, the scheduler) keep running.
+
+Sized for IO concurrency (default 16). For CPU-heavy stages we still rely
+on the GIL releasing in C extensions (fitz / Pillow / cairosvg) plus
+asyncio.create_subprocess_exec for true OS-level parallelism on pandoc /
+pdflatex.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, TypeVar
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+_pool: ThreadPoolExecutor | None = None
+
+
+def init_offload(workers: int) -> None:
+    """Create the global offload pool. Idempotent."""
+    global _pool
+    if _pool is not None:
+        return
+    if workers < 1:
+        workers = 1
+    _pool = ThreadPoolExecutor(
+        max_workers=workers,
+        thread_name_prefix="ppt-offload",
+    )
+    logger.info("offload pool started (workers=%d)", workers)
+
+
+def shutdown_offload(wait: bool = True) -> None:
+    """Tear down the global pool. Idempotent."""
+    global _pool
+    if _pool is None:
+        return
+    pool = _pool
+    _pool = None
+    try:
+        pool.shutdown(wait=wait, cancel_futures=True)
+    except TypeError:  # pragma: no cover — Python <3.9 compat
+        pool.shutdown(wait=wait)
+    logger.info("offload pool stopped")
+
+
+async def aoffload(fn: Callable[..., _T], /, *args: Any, **kwargs: Any) -> _T:
+    """Run a sync callable on the global offload pool.
+
+    Falls back to the loop's default executor if ``init_offload`` was never
+    called (e.g. unit tests that import a module directly), so callers never
+    have to defensively check.
+    """
+    loop = asyncio.get_running_loop()
+    pool = _pool  # local to avoid TOCTOU during shutdown
+
+    def _invoke() -> _T:
+        return fn(*args, **kwargs)
+
+    return await loop.run_in_executor(pool, _invoke)

--- a/backend/runtime/scheduler.py
+++ b/backend/runtime/scheduler.py
@@ -1,35 +1,10 @@
-"""Job scheduler with bounded queue and configurable concurrency.
+"""Immediate job runner.
 
-Every long-running job (generate / refine) is submitted here instead of
-being launched directly from the HTTP handler. This guarantees:
-
-    * the HTTP handler returns in O(ms) regardless of how many jobs are
-      already queued or running — fixing the symptom where "starting a new
-      PPT" hung while another job was in the parsing stage;
-
-    * total in-flight work is capped by ``settings.max_concurrent_jobs``,
-      so we never exhaust the global IO pool / external tools (pandoc,
-      pdflatex) by overloading them with parallel runs;
-
-    * the queue itself has a hard cap (``settings.job_queue_capacity``)
-      so an attacker / runaway client can't grow memory unbounded; the
-      submit path returns ``QueueFull`` which the API surface translates
-      into HTTP 429.
-
-Cancellation has two-stage semantics:
-
-    * If the job is *running*, ``cancel(job_id)`` calls ``task.cancel()``
-      which propagates ``asyncio.CancelledError`` into the coroutine; the
-      pipeline catches that, runs cleanup, and emits a ``cancelled``
-      progress event.
-
-    * If the job is still *queued*, ``cancel`` flips it in the cancel set
-      and the worker skips it on dequeue. We don't try to delete from the
-      PriorityQueue (that's O(n) and racy); lazy skip is simpler and
-      correct.
-
-The scheduler does not own job state — it only owns the *task lifecycle*.
-``SessionManager`` continues to be the source of truth for ``Job`` rows.
+The API process should never serialize user jobs behind a shared queue.
+Each submitted generate/refine request gets its own asyncio task immediately,
+with lifecycle state tracked by job_id. Resource-heavy sync work is still
+isolated through ``backend.runtime.aoffload`` / async subprocess helpers, but
+the scheduler itself has no backlog and no priority ordering.
 """
 
 from __future__ import annotations
@@ -40,98 +15,92 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine
 
-from backend.config import settings
-
 logger = logging.getLogger(__name__)
 
 
 class SchedulerDraining(RuntimeError):
-    """Submitted after the scheduler started shutting down."""
+    """Submitted after the runner started shutting down."""
 
 
 class QueueFull(RuntimeError):
-    """The bounded queue is at capacity. Caller should map to HTTP 429."""
+    """Compatibility exception; immediate mode does not raise this."""
 
 
-# Lower priority value = runs sooner. Default 10; refines could pass 5
-# in the future to jump the queue, generate stays at 10.
 DEFAULT_PRIORITY = 10
 JobRunner = Callable[[], Coroutine[Any, Any, None]]
 
 
-@dataclass(order=True)
-class _QueueItem:
-    priority: int
-    submit_ts: float = field(compare=True)
-    job_id: str = field(compare=False)
-    runner: JobRunner = field(compare=False)
+@dataclass
+class _RunningJob:
+    job_id: str
+    task: asyncio.Task[Any]
+    submit_ts: float = field(default_factory=time.monotonic)
+    priority: int = DEFAULT_PRIORITY
 
 
 class Scheduler:
-    """Single-process priority scheduler with N concurrent workers."""
+    """Immediate per-job task runner.
+
+    ``max_concurrent`` and ``queue_capacity`` are accepted for backwards
+    compatibility with tests/config, but they do not limit submissions.
+    """
 
     def __init__(
         self,
         max_concurrent: int | None = None,
         queue_capacity: int | None = None,
     ) -> None:
-        self._max_concurrent = max_concurrent or settings.max_concurrent_jobs
-        capacity = queue_capacity or settings.job_queue_capacity
-        self._queue: asyncio.PriorityQueue[_QueueItem] = asyncio.PriorityQueue(
-            maxsize=capacity
-        )
-        self._running: dict[str, asyncio.Task[Any]] = {}
-        self._cancelled_queued: set[str] = set()
-        self._sem = asyncio.Semaphore(self._max_concurrent)
-        self._workers: list[asyncio.Task[None]] = []
+        self._running: dict[str, _RunningJob] = {}
         self._draining = False
         self._started = False
 
     @property
     def queue_size(self) -> int:
-        return self._queue.qsize()
+        return 0
 
     @property
     def running_count(self) -> int:
-        return sum(1 for t in self._running.values() if not t.done())
+        return sum(1 for item in self._running.values() if not item.task.done())
+
+    def diagnostics(self) -> dict[str, Any]:
+        return {
+            "mode": "immediate",
+            "started": self._started,
+            "draining": self._draining,
+            "queue_size": 0,
+            "queue_capacity": 0,
+            "queued_job_ids": [],
+            "running_count": self.running_count,
+            "running_job_ids": [
+                job_id
+                for job_id, item in self._running.items()
+                if not item.task.done()
+            ],
+        }
 
     async def start(self) -> None:
-        if self._started:
-            return
         self._started = True
-        # We run a single dispatcher loop and use a Semaphore for concurrency
-        # control. This keeps priority semantics intact: every dequeued item
-        # is the highest-priority one *at that moment*, even when many are
-        # queued at the same time as a slot frees up.
-        self._workers.append(
-            asyncio.create_task(self._dispatch_loop(), name="scheduler-dispatch")
-        )
+        self._draining = False
 
     async def shutdown(self, timeout: float = 30.0) -> None:
-        """Stop accepting new jobs, wait for in-flight ones, then return.
-
-        Workers in flight get ``timeout`` seconds to flush their final
-        progress event before we cancel them outright.
-        """
         self._draining = True
-
         deadline = time.monotonic() + timeout
-        while self._running and time.monotonic() < deadline:
+        while self.running_count and time.monotonic() < deadline:
             await asyncio.sleep(0.1)
 
-        for jid, task in list(self._running.items()):
-            if not task.done():
-                logger.warning("scheduler: cancelling job %s on shutdown", jid)
-                task.cancel()
+        for job_id, item in list(self._running.items()):
+            if not item.task.done():
+                logger.warning("scheduler: cancelling job %s on shutdown", job_id)
+                item.task.cancel()
 
-        for w in self._workers:
-            w.cancel()
-        for w in self._workers:
+        for item in list(self._running.values()):
             try:
-                await w
+                await item.task
             except (asyncio.CancelledError, Exception):
                 pass
-        self._workers.clear()
+
+        self._running.clear()
+        self._started = False
 
     async def submit(
         self,
@@ -140,82 +109,52 @@ class Scheduler:
         *,
         priority: int = DEFAULT_PRIORITY,
     ) -> int:
-        """Enqueue a job. Returns the queue size after insertion."""
+        """Start a job immediately. Returns 0 because there is no queue."""
         if self._draining:
             raise SchedulerDraining("scheduler is shutting down")
         if not self._started:
             await self.start()
-        item = _QueueItem(
-            priority=priority,
-            submit_ts=time.monotonic(),
-            job_id=job_id,
-            runner=runner,
+
+        if job_id in self._running and not self._running[job_id].task.done():
+            raise RuntimeError(f"job {job_id} is already running")
+
+        task = asyncio.create_task(
+            self._run_one(job_id, runner),
+            name=f"job-{job_id}",
         )
-        try:
-            self._queue.put_nowait(item)
-        except asyncio.QueueFull as exc:
-            raise QueueFull(
-                f"job queue at capacity ({self._queue.maxsize})"
-            ) from exc
-        return self._queue.qsize()
+        self._running[job_id] = _RunningJob(
+            job_id=job_id,
+            task=task,
+            priority=priority,
+        )
+        return 0
 
     def cancel(self, job_id: str) -> bool:
-        """Cancel a job whether it's running or still queued.
-
-        Returns True if a cancellation was actually delivered.
-        """
-        task = self._running.get(job_id)
-        if task is not None and not task.done():
-            task.cancel()
-            return True
-        # Queued: lazy mark; the dispatcher will skip it on dequeue.
-        self._cancelled_queued.add(job_id)
+        item = self._running.get(job_id)
+        if item is None or item.task.done():
+            return False
+        item.task.cancel()
         return True
 
     def is_active(self, job_id: str) -> bool:
-        if job_id in self._running:
-            return True
-        return any(
-            item.job_id == job_id
-            for item in list(getattr(self._queue, "_queue", []))  # type: ignore[attr-defined]
-        )
+        item = self._running.get(job_id)
+        return bool(item and not item.task.done())
 
-    async def _dispatch_loop(self) -> None:
-        while not self._draining:
-            try:
-                item = await self._queue.get()
-            except asyncio.CancelledError:
-                return
-
-            if item.job_id in self._cancelled_queued:
-                self._cancelled_queued.discard(item.job_id)
-                logger.info("scheduler: skipping cancelled queued job %s", item.job_id)
-                continue
-
-            await self._sem.acquire()
-            asyncio.create_task(
-                self._run_one(item),
-                name=f"scheduler-run-{item.job_id}",
-            )
-
-    async def _run_one(self, item: _QueueItem) -> None:
-        job_id = item.job_id
+    async def _run_one(self, job_id: str, runner: JobRunner) -> None:
+        started = time.monotonic()
+        logger.info("scheduler: starting independent job %s", job_id)
         try:
-            wait_secs = time.monotonic() - item.submit_ts
-            logger.info(
-                "scheduler: starting job %s (queued %.1fs)", job_id, wait_secs
-            )
-            task = asyncio.create_task(item.runner(), name=f"job-{job_id}")
-            self._running[job_id] = task
-            try:
-                await task
-            except asyncio.CancelledError:
-                logger.info("scheduler: job %s cancelled", job_id)
-            except Exception:
-                logger.exception("scheduler: job %s raised unhandled exception", job_id)
+            await runner()
+        except asyncio.CancelledError:
+            logger.info("scheduler: job %s cancelled", job_id)
+        except Exception:
+            logger.exception("scheduler: job %s raised unhandled exception", job_id)
         finally:
-            self._running.pop(job_id, None)
-            self._sem.release()
+            elapsed = time.monotonic() - started
+            logger.info("scheduler: job %s finished after %.1fs", job_id, elapsed)
+            current = self._running.get(job_id)
+            if current is not None and current.task is asyncio.current_task():
+                self._running.pop(job_id, None)
 
 
 _scheduler: Scheduler | None = None

--- a/backend/runtime/scheduler.py
+++ b/backend/runtime/scheduler.py
@@ -1,0 +1,228 @@
+"""Job scheduler with bounded queue and configurable concurrency.
+
+Every long-running job (generate / refine) is submitted here instead of
+being launched directly from the HTTP handler. This guarantees:
+
+    * the HTTP handler returns in O(ms) regardless of how many jobs are
+      already queued or running — fixing the symptom where "starting a new
+      PPT" hung while another job was in the parsing stage;
+
+    * total in-flight work is capped by ``settings.max_concurrent_jobs``,
+      so we never exhaust the global IO pool / external tools (pandoc,
+      pdflatex) by overloading them with parallel runs;
+
+    * the queue itself has a hard cap (``settings.job_queue_capacity``)
+      so an attacker / runaway client can't grow memory unbounded; the
+      submit path returns ``QueueFull`` which the API surface translates
+      into HTTP 429.
+
+Cancellation has two-stage semantics:
+
+    * If the job is *running*, ``cancel(job_id)`` calls ``task.cancel()``
+      which propagates ``asyncio.CancelledError`` into the coroutine; the
+      pipeline catches that, runs cleanup, and emits a ``cancelled``
+      progress event.
+
+    * If the job is still *queued*, ``cancel`` flips it in the cancel set
+      and the worker skips it on dequeue. We don't try to delete from the
+      PriorityQueue (that's O(n) and racy); lazy skip is simpler and
+      correct.
+
+The scheduler does not own job state — it only owns the *task lifecycle*.
+``SessionManager`` continues to be the source of truth for ``Job`` rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine
+
+from backend.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulerDraining(RuntimeError):
+    """Submitted after the scheduler started shutting down."""
+
+
+class QueueFull(RuntimeError):
+    """The bounded queue is at capacity. Caller should map to HTTP 429."""
+
+
+# Lower priority value = runs sooner. Default 10; refines could pass 5
+# in the future to jump the queue, generate stays at 10.
+DEFAULT_PRIORITY = 10
+JobRunner = Callable[[], Coroutine[Any, Any, None]]
+
+
+@dataclass(order=True)
+class _QueueItem:
+    priority: int
+    submit_ts: float = field(compare=True)
+    job_id: str = field(compare=False)
+    runner: JobRunner = field(compare=False)
+
+
+class Scheduler:
+    """Single-process priority scheduler with N concurrent workers."""
+
+    def __init__(
+        self,
+        max_concurrent: int | None = None,
+        queue_capacity: int | None = None,
+    ) -> None:
+        self._max_concurrent = max_concurrent or settings.max_concurrent_jobs
+        capacity = queue_capacity or settings.job_queue_capacity
+        self._queue: asyncio.PriorityQueue[_QueueItem] = asyncio.PriorityQueue(
+            maxsize=capacity
+        )
+        self._running: dict[str, asyncio.Task[Any]] = {}
+        self._cancelled_queued: set[str] = set()
+        self._sem = asyncio.Semaphore(self._max_concurrent)
+        self._workers: list[asyncio.Task[None]] = []
+        self._draining = False
+        self._started = False
+
+    @property
+    def queue_size(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def running_count(self) -> int:
+        return sum(1 for t in self._running.values() if not t.done())
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        # We run a single dispatcher loop and use a Semaphore for concurrency
+        # control. This keeps priority semantics intact: every dequeued item
+        # is the highest-priority one *at that moment*, even when many are
+        # queued at the same time as a slot frees up.
+        self._workers.append(
+            asyncio.create_task(self._dispatch_loop(), name="scheduler-dispatch")
+        )
+
+    async def shutdown(self, timeout: float = 30.0) -> None:
+        """Stop accepting new jobs, wait for in-flight ones, then return.
+
+        Workers in flight get ``timeout`` seconds to flush their final
+        progress event before we cancel them outright.
+        """
+        self._draining = True
+
+        deadline = time.monotonic() + timeout
+        while self._running and time.monotonic() < deadline:
+            await asyncio.sleep(0.1)
+
+        for jid, task in list(self._running.items()):
+            if not task.done():
+                logger.warning("scheduler: cancelling job %s on shutdown", jid)
+                task.cancel()
+
+        for w in self._workers:
+            w.cancel()
+        for w in self._workers:
+            try:
+                await w
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._workers.clear()
+
+    async def submit(
+        self,
+        job_id: str,
+        runner: JobRunner,
+        *,
+        priority: int = DEFAULT_PRIORITY,
+    ) -> int:
+        """Enqueue a job. Returns the queue size after insertion."""
+        if self._draining:
+            raise SchedulerDraining("scheduler is shutting down")
+        if not self._started:
+            await self.start()
+        item = _QueueItem(
+            priority=priority,
+            submit_ts=time.monotonic(),
+            job_id=job_id,
+            runner=runner,
+        )
+        try:
+            self._queue.put_nowait(item)
+        except asyncio.QueueFull as exc:
+            raise QueueFull(
+                f"job queue at capacity ({self._queue.maxsize})"
+            ) from exc
+        return self._queue.qsize()
+
+    def cancel(self, job_id: str) -> bool:
+        """Cancel a job whether it's running or still queued.
+
+        Returns True if a cancellation was actually delivered.
+        """
+        task = self._running.get(job_id)
+        if task is not None and not task.done():
+            task.cancel()
+            return True
+        # Queued: lazy mark; the dispatcher will skip it on dequeue.
+        self._cancelled_queued.add(job_id)
+        return True
+
+    def is_active(self, job_id: str) -> bool:
+        if job_id in self._running:
+            return True
+        return any(
+            item.job_id == job_id
+            for item in list(getattr(self._queue, "_queue", []))  # type: ignore[attr-defined]
+        )
+
+    async def _dispatch_loop(self) -> None:
+        while not self._draining:
+            try:
+                item = await self._queue.get()
+            except asyncio.CancelledError:
+                return
+
+            if item.job_id in self._cancelled_queued:
+                self._cancelled_queued.discard(item.job_id)
+                logger.info("scheduler: skipping cancelled queued job %s", item.job_id)
+                continue
+
+            await self._sem.acquire()
+            asyncio.create_task(
+                self._run_one(item),
+                name=f"scheduler-run-{item.job_id}",
+            )
+
+    async def _run_one(self, item: _QueueItem) -> None:
+        job_id = item.job_id
+        try:
+            wait_secs = time.monotonic() - item.submit_ts
+            logger.info(
+                "scheduler: starting job %s (queued %.1fs)", job_id, wait_secs
+            )
+            task = asyncio.create_task(item.runner(), name=f"job-{job_id}")
+            self._running[job_id] = task
+            try:
+                await task
+            except asyncio.CancelledError:
+                logger.info("scheduler: job %s cancelled", job_id)
+            except Exception:
+                logger.exception("scheduler: job %s raised unhandled exception", job_id)
+        finally:
+            self._running.pop(job_id, None)
+            self._sem.release()
+
+
+_scheduler: Scheduler | None = None
+
+
+def get_scheduler() -> Scheduler:
+    global _scheduler
+    if _scheduler is None:
+        _scheduler = Scheduler()
+    return _scheduler

--- a/backend/runtime/subproc.py
+++ b/backend/runtime/subproc.py
@@ -1,0 +1,191 @@
+"""Async subprocess helper with hard timeout and process-group cleanup.
+
+All ``subprocess.run`` / ``Popen`` calls in the codebase must be routed
+through ``arun``. It guarantees:
+
+    * the call yields to the event loop while the child runs (so the API
+      stays responsive while pandoc/pdflatex/cairosvg execute);
+    * timeouts are enforced by the loop itself, then escalated to a hard
+      kill of the whole process *group* (so children of the child — for
+      example pandoc's helper processes — also die);
+    * stdout/stderr are captured asynchronously to avoid pipe deadlocks.
+
+Cross-platform notes:
+
+    * POSIX: ``start_new_session=True`` puts the child in its own process
+      group; we signal ``-pid`` to reap the whole tree.
+    * Windows: we pass ``CREATE_NEW_PROCESS_GROUP`` and use ``terminate()``
+      then ``kill()`` if it doesn't exit. ``CTRL_BREAK_EVENT`` would also
+      work but ``terminate`` is sufficient for the tools we shell out to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+_IS_WINDOWS = sys.platform.startswith("win")
+
+
+class SubprocessError(RuntimeError):
+    """Non-zero exit from a subprocess."""
+
+    def __init__(self, argv: Sequence[str], returncode: int, stdout: str, stderr: str):
+        super().__init__(
+            f"{argv[0] if argv else '<empty>'} exited with code {returncode}: "
+            f"{stderr.strip()[:500]}"
+        )
+        self.argv = list(argv)
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class SubprocessTimeout(SubprocessError):
+    """Subprocess exceeded its timeout and was killed."""
+
+    def __init__(self, argv: Sequence[str], timeout: float, stdout: str, stderr: str):
+        super().__init__(argv, returncode=-1, stdout=stdout, stderr=stderr)
+        self.timeout = timeout
+        # Reset the message produced by the parent class.
+        self.args = (
+            f"{argv[0] if argv else '<empty>'} timed out after {timeout:.1f}s",
+        )
+
+
+@dataclass(slots=True)
+class CompletedProcess:
+    argv: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+async def _terminate_tree(proc: asyncio.subprocess.Process) -> None:
+    """Best-effort kill of the child and its descendants.
+
+    Sends SIGTERM (Windows: terminate), waits up to 5s, then SIGKILL.
+    Always swallows OSError because the child may have exited between the
+    check and the signal.
+    """
+    if proc.returncode is not None:
+        return
+
+    # ``os.killpg`` and ``signal.SIGKILL`` only exist on POSIX. We guard with
+    # ``_IS_WINDOWS`` and use ``getattr`` to keep static type-checkers happy
+    # on Windows where these names are not defined on the module objects.
+    _killpg = getattr(os, "killpg", None)
+    _sigterm = getattr(signal, "SIGTERM", 15)
+    _sigkill = getattr(signal, "SIGKILL", 9)
+
+    try:
+        if _IS_WINDOWS or _killpg is None:
+            proc.terminate()
+        else:
+            _killpg(proc.pid, _sigterm)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=5.0)
+        return
+    except asyncio.TimeoutError:
+        pass
+
+    try:
+        if _IS_WINDOWS or _killpg is None:
+            proc.kill()
+        else:
+            _killpg(proc.pid, _sigkill)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+    try:
+        await proc.wait()
+    except Exception:  # pragma: no cover
+        pass
+
+
+async def arun(
+    argv: Sequence[str],
+    *,
+    timeout: float,
+    cwd: Path | str | None = None,
+    env: Mapping[str, str] | None = None,
+    stdin: bytes | None = None,
+    check: bool = True,
+    encoding: str = "utf-8",
+) -> CompletedProcess:
+    """Run a command asynchronously with a hard timeout.
+
+    Raises ``SubprocessTimeout`` if the timeout elapses, ``SubprocessError``
+    if ``check`` is True and the exit code is non-zero. Otherwise returns a
+    ``CompletedProcess`` with decoded stdout/stderr.
+    """
+    if not argv:
+        raise ValueError("argv must not be empty")
+
+    argv_list = [str(a) for a in argv]
+    cwd_str = str(cwd) if cwd is not None else None
+
+    creation_kwargs: dict = {}
+    if _IS_WINDOWS:
+        # CREATE_NEW_PROCESS_GROUP = 0x00000200
+        creation_kwargs["creationflags"] = 0x00000200
+    else:
+        creation_kwargs["start_new_session"] = True
+
+    proc = await asyncio.create_subprocess_exec(
+        *argv_list,
+        stdin=asyncio.subprocess.PIPE if stdin is not None else asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd_str,
+        env=dict(env) if env is not None else None,
+        **creation_kwargs,
+    )
+
+    try:
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(input=stdin),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            await _terminate_tree(proc)
+            # Drain whatever is buffered. communicate() after kill returns
+            # quickly on every platform we support.
+            try:
+                stdout_b, stderr_b = await asyncio.wait_for(
+                    proc.communicate(), timeout=2.0
+                )
+            except (asyncio.TimeoutError, Exception):
+                stdout_b, stderr_b = b"", b""
+            stdout = stdout_b.decode(encoding, errors="replace") if stdout_b else ""
+            stderr = stderr_b.decode(encoding, errors="replace") if stderr_b else ""
+            raise SubprocessTimeout(argv_list, timeout, stdout, stderr)
+        except asyncio.CancelledError:
+            await _terminate_tree(proc)
+            raise
+    finally:
+        # Defensive: if for some reason the child is still running (e.g. an
+        # exception path we didn't anticipate), make sure we don't leak it.
+        if proc.returncode is None:
+            await _terminate_tree(proc)
+
+    stdout = stdout_b.decode(encoding, errors="replace") if stdout_b else ""
+    stderr = stderr_b.decode(encoding, errors="replace") if stderr_b else ""
+    rc = proc.returncode if proc.returncode is not None else -1
+
+    if check and rc != 0:
+        raise SubprocessError(argv_list, rc, stdout, stderr)
+
+    return CompletedProcess(argv=argv_list, returncode=rc, stdout=stdout, stderr=stderr)

--- a/backend/session/manager.py
+++ b/backend/session/manager.py
@@ -413,11 +413,13 @@ class SessionManager:
                     continue
                 self._dirty = False
                 try:
-                    # Off the event loop — full JSON serialization for a
-                    # fat payload is cheap (<5ms) but still polite.
+                    # Build the snapshot on the event-loop thread so the
+                    # offload worker never iterates mutable SessionManager
+                    # dicts while other requests are updating them.
+                    payload = self._build_state_payload()
                     from backend.runtime.offload import aoffload
 
-                    await aoffload(self._write_state_blocking)
+                    await aoffload(self._write_payload_blocking, payload)
                 except asyncio.CancelledError:
                     raise
                 except Exception:
@@ -428,19 +430,26 @@ class SessionManager:
             # recent metadata if the loop is cancelled before debounce.
             if self._dirty:
                 try:
-                    self._write_state_blocking()
+                    self._write_payload_blocking(self._build_state_payload())
                 except Exception:
                     logger.exception("final session state flush failed")
             raise
 
     def _write_state_blocking(self) -> None:
-        self._state_file.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
+        self._write_payload_blocking(self._build_state_payload())
+
+    def _build_state_payload(self) -> dict[str, Any]:
+        return {
             "sessions": [
-                self._serialize_session(session) for session in self._sessions.values()
+                self._serialize_session(session) for session in list(self._sessions.values())
             ],
-            "jobs": [self._serialize_job(job) for job in self._jobs.values()],
+            "jobs": [
+                self._serialize_job(job) for job in list(self._jobs.values())
+            ],
         }
+
+    def _write_payload_blocking(self, payload: dict[str, Any]) -> None:
+        self._state_file.parent.mkdir(parents=True, exist_ok=True)
         temp_path = self._state_file.with_suffix(".tmp")
         temp_path.write_text(
             json.dumps(payload, ensure_ascii=False, indent=2),

--- a/backend/session/manager.py
+++ b/backend/session/manager.py
@@ -1,9 +1,31 @@
-"""Session and job lifecycle management."""
+"""Session and job lifecycle management.
+
+Persistence strategy:
+
+    The in-memory dict is the source of truth. ``session_state.json`` is
+    just a snapshot used to recover Job/Session metadata across server
+    restarts. Writing the full snapshot on every event update is wasteful
+    (an active job emits hundreds of progress events; each one used to
+    rewrite a multi-MB JSON), so the snapshot is *debounced*:
+
+      * ``record_event`` / ``update_job`` / ``create_*`` mark the state
+        dirty in-memory, then schedule a flush via ``_request_flush``;
+      * a single background task drains the dirty flag every
+        ``settings.persist_debounce_ms``, writing one consolidated JSON;
+      * if asyncio is not running yet (e.g. unit-test imports), we fall
+        back to an immediate synchronous write so behaviour stays correct.
+
+    Worst case on a hard crash we lose the last 200ms of *metadata*
+    snapshots. Events themselves are still in memory; they would also be
+    lost on a crash, which is acceptable: a fresh-restarted server marks
+    in-flight jobs as errored anyway via ``_mark_orphaned_running_jobs``.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import shutil
 import time
 import uuid
@@ -12,6 +34,8 @@ from pathlib import Path
 from typing import Any
 
 from backend.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 # Maximum number of recent events kept on disk per job, used for replay
@@ -72,6 +96,10 @@ class SessionManager:
         self._jobs: dict[str, Job] = {}
         self._ws_queues: dict[str, list[asyncio.Queue]] = {}
         self._tasks: dict[str, asyncio.Task[Any]] = {}
+        # Debounced persistence — see module docstring.
+        self._dirty: bool = False
+        self._flush_task: asyncio.Task[None] | None = None
+        self._flush_event: asyncio.Event | None = None
         self._load_state()
         self._mark_orphaned_running_jobs()
 
@@ -157,6 +185,18 @@ class SessionManager:
         task.add_done_callback(_cleanup)
 
     def cancel_job(self, job_id: str) -> bool:
+        # Prefer the scheduler when it's been wired in: it knows about both
+        # running tasks *and* still-queued ones (which we can't reach via
+        # ``self._tasks``). Falls through to legacy task cancellation when
+        # the scheduler module isn't loaded (early startup, tests).
+        try:
+            from backend.runtime.scheduler import get_scheduler
+
+            if get_scheduler().cancel(job_id):
+                return True
+        except Exception:
+            pass
+
         task = self._tasks.get(job_id)
         if task is None or task.done():
             return False
@@ -254,9 +294,13 @@ class SessionManager:
             job.events = job.events[-EVENT_RING_SIZE:]
         self._persist_state()
 
+        # Fan out to live subscribers with drop-oldest backpressure. A slow
+        # client must not back-pressure the producer (the pipeline) — we'd
+        # rather show the user a *current* progress frame than a stale one,
+        # and the client can request a replay over the seq range it missed.
         if job_id in self._ws_queues:
             for queue in self._ws_queues[job_id]:
-                queue.put_nowait(event)
+                _offer_to_queue(queue, event)
 
     def get_events_after(self, job_id: str, since_seq: int) -> list[dict]:
         """Return all retained events with seq > *since_seq*, in order."""
@@ -268,8 +312,14 @@ class SessionManager:
         return [ev for ev in job.events if int(ev.get("seq", 0)) > since_seq]
 
     def subscribe_ws(self, job_id: str) -> asyncio.Queue:
-        """Subscribe to WebSocket events for a job."""
-        queue: asyncio.Queue = asyncio.Queue()
+        """Subscribe to WebSocket events for a job.
+
+        The queue is bounded by ``settings.ws_subscriber_queue_size``; when
+        full, the oldest pending frame is dropped to make room for the new
+        one. This protects the producer from a single slow socket without
+        introducing any cross-subscriber blocking.
+        """
+        queue: asyncio.Queue = asyncio.Queue(maxsize=settings.ws_subscriber_queue_size)
         if job_id not in self._ws_queues:
             self._ws_queues[job_id] = []
         self._ws_queues[job_id].append(queue)
@@ -320,9 +370,75 @@ class SessionManager:
             self._persist_state()
 
     def _persist_state(self) -> None:
+        """Debounced persistence entry point.
+
+        From an event-loop context this only marks the state dirty and asks
+        the background flusher to wake up. From a non-loop context (early
+        import, tests) it falls back to the synchronous write so existing
+        callers keep working.
+        """
+        self._dirty = True
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop yet — write synchronously so module-import-time
+            # mutations still hit disk.
+            self._write_state_blocking()
+            self._dirty = False
+            return
+
+        if self._flush_task is None or self._flush_task.done():
+            self._flush_event = asyncio.Event()
+            self._flush_task = asyncio.create_task(
+                self._flush_loop(), name="session-state-flusher"
+            )
+        if self._flush_event is not None:
+            self._flush_event.set()
+
+    async def _flush_loop(self) -> None:
+        """Coalesce rapid-fire dirty flags into one disk write per window."""
+        debounce = max(0.05, settings.persist_debounce_ms / 1000.0)
+        try:
+            while True:
+                ev = self._flush_event
+                if ev is None:
+                    return
+                await ev.wait()
+                ev.clear()
+                if not self._dirty:
+                    continue
+                # Sleep to absorb any further updates within the window.
+                await asyncio.sleep(debounce)
+                if not self._dirty:
+                    continue
+                self._dirty = False
+                try:
+                    # Off the event loop — full JSON serialization for a
+                    # fat payload is cheap (<5ms) but still polite.
+                    from backend.runtime.offload import aoffload
+
+                    await aoffload(self._write_state_blocking)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("session state flush failed")
+                    self._dirty = True
+        except asyncio.CancelledError:
+            # On shutdown, write one last time so we don't lose the most
+            # recent metadata if the loop is cancelled before debounce.
+            if self._dirty:
+                try:
+                    self._write_state_blocking()
+                except Exception:
+                    logger.exception("final session state flush failed")
+            raise
+
+    def _write_state_blocking(self) -> None:
         self._state_file.parent.mkdir(parents=True, exist_ok=True)
         payload = {
-            "sessions": [self._serialize_session(session) for session in self._sessions.values()],
+            "sessions": [
+                self._serialize_session(session) for session in self._sessions.values()
+            ],
             "jobs": [self._serialize_job(job) for job in self._jobs.values()],
         }
         temp_path = self._state_file.with_suffix(".tmp")
@@ -406,6 +522,25 @@ class SessionManager:
         payload["events"] = list(job.events[-EVENT_RING_SIZE:])
         payload["last_seq"] = job.last_seq
         return payload
+
+
+def _offer_to_queue(queue: asyncio.Queue, event: dict) -> None:
+    """Drop-oldest publish onto a bounded subscriber queue."""
+    try:
+        queue.put_nowait(event)
+        return
+    except asyncio.QueueFull:
+        pass
+    # Drop the oldest pending frame and retry. Best effort: if the queue
+    # is concurrently drained by the consumer between checks, just bail.
+    try:
+        queue.get_nowait()
+    except asyncio.QueueEmpty:
+        return
+    try:
+        queue.put_nowait(event)
+    except asyncio.QueueFull:  # pragma: no cover — extremely unlikely race
+        pass
 
 
 # Global singleton

--- a/frontend/src/components/config/OptionsPanel.tsx
+++ b/frontend/src/components/config/OptionsPanel.tsx
@@ -1,4 +1,5 @@
-import { BookOpen, Eye, FlaskConical, HelpCircle, Key, Layers, Puzzle, Search, Settings2, Sparkles } from "lucide-react";
+import { useState } from "react";
+import { BookOpen, Eye, EyeOff, FlaskConical, HelpCircle, Key, Layers, Puzzle, Search, Settings2, Sparkles } from "lucide-react";
 import { useLocale } from "../../i18n";
 import type { ResearchConfig, TemplateInfo } from "../../lib/types";
 import { FontSelector } from "./FontSelector";
@@ -50,6 +51,10 @@ interface OptionsPanelProps {
 
 export function OptionsPanel(props: OptionsPanelProps) {
   const { t } = useLocale();
+  const [showGeminiKey, setShowGeminiKey] = useState(false);
+  const [showScholarKey, setShowScholarKey] = useState(false);
+  const [showTavilyKey, setShowTavilyKey] = useState(false);
+  const [showSerpApiKey, setShowSerpApiKey] = useState(false);
   return (
     <section className="panel">
       <div className="panel-title-row" style={{ marginBottom: "0.75rem" }}>
@@ -297,12 +302,23 @@ export function OptionsPanel(props: OptionsPanelProps) {
                   <Key size={12} style={{ marginRight: 4, verticalAlign: "middle" }} />
                   Gemini API Key
                 </span>
-                <input
-                  type="password"
-                  value={props.geminiApiKey}
-                  onChange={(event) => props.onGeminiApiKeyChange(event.target.value)}
-                  placeholder="AIza..."
-                />
+                <div className="form-field-icon api-key-wrapper">
+                  <Key size={14} className="field-icon" />
+                  <input
+                    type={showGeminiKey ? "text" : "password"}
+                    value={props.geminiApiKey}
+                    onChange={(event) => props.onGeminiApiKeyChange(event.target.value)}
+                    placeholder="AIza..."
+                  />
+                  <button
+                    type="button"
+                    className="api-key-toggle"
+                    onClick={() => setShowGeminiKey((v) => !v)}
+                    tabIndex={-1}
+                  >
+                    {showGeminiKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                  </button>
+                </div>
               </label>
             ) : null}
           </div>
@@ -447,17 +463,28 @@ export function OptionsPanel(props: OptionsPanelProps) {
                     <Key size={12} style={{ marginRight: 4, verticalAlign: "middle" }} />
                     {t("options.semanticScholarApiKey")}
                   </span>
-                  <input
-                    type="password"
-                    value={props.researchConfig.semantic_scholar_api_key ?? ""}
-                    onChange={(event) => {
-                      props.onResearchConfigChange({
-                        ...props.researchConfig,
-                        semantic_scholar_api_key: event.target.value || undefined,
-                      });
-                    }}
-                    placeholder={t("options.semanticScholarApiKeyPlaceholder")}
-                  />
+                  <div className="form-field-icon api-key-wrapper">
+                    <Key size={14} className="field-icon" />
+                    <input
+                      type={showScholarKey ? "text" : "password"}
+                      value={props.researchConfig.semantic_scholar_api_key ?? ""}
+                      onChange={(event) => {
+                        props.onResearchConfigChange({
+                          ...props.researchConfig,
+                          semantic_scholar_api_key: event.target.value || undefined,
+                        });
+                      }}
+                      placeholder={t("options.semanticScholarApiKeyPlaceholder")}
+                    />
+                    <button
+                      type="button"
+                      className="api-key-toggle"
+                      onClick={() => setShowScholarKey((v) => !v)}
+                      tabIndex={-1}
+                    >
+                      {showScholarKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                    </button>
+                  </div>
                 </label>
               </div>
             ) : null}
@@ -503,41 +530,97 @@ export function OptionsPanel(props: OptionsPanelProps) {
             </label>
             {props.researchConfig.web_search_enabled ? (
               <div className="options-icon-sub">
-                <label className="form-field options-api-key-field">
-                  <span>
-                    <Key size={12} style={{ marginRight: 4, verticalAlign: "middle" }} />
-                    {t("options.tavilyApiKey")}
-                  </span>
-                  <input
-                    type="password"
-                    value={props.researchConfig.tavily_api_key ?? ""}
-                    onChange={(event) => {
-                      props.onResearchConfigChange({
-                        ...props.researchConfig,
-                        tavily_api_key: event.target.value || undefined,
-                      });
-                    }}
-                    placeholder="tvly-..."
-                  />
-                </label>
-                <label className="form-field options-api-key-field">
-                  <span>
-                    <Key size={12} style={{ marginRight: 4, verticalAlign: "middle" }} />
-                    {t("options.serpApiKey")}
-                  </span>
-                  <input
-                    type="password"
-                    value={props.researchConfig.serpapi_key ?? ""}
-                    onChange={(event) => {
-                      props.onResearchConfigChange({
-                        ...props.researchConfig,
-                        serpapi_key: event.target.value || undefined,
-                      });
-                    }}
-                    placeholder="serp-..."
-                  />
-                </label>
-                {!props.researchConfig.tavily_api_key && !props.researchConfig.serpapi_key ? (
+                <div className="research-provider-select">
+                  <label className="research-provider-option">
+                    <input
+                      type="radio"
+                      name="web-search-provider"
+                      checked={(props.researchConfig.web_search_provider ?? "tavily") === "tavily"}
+                      onChange={() => {
+                        props.onResearchConfigChange({
+                          ...props.researchConfig,
+                          web_search_provider: "tavily",
+                        });
+                      }}
+                    />
+                    <span>{t("options.tavilyApiKey")}</span>
+                  </label>
+                  <label className="research-provider-option">
+                    <input
+                      type="radio"
+                      name="web-search-provider"
+                      checked={props.researchConfig.web_search_provider === "serpapi"}
+                      onChange={() => {
+                        props.onResearchConfigChange({
+                          ...props.researchConfig,
+                          web_search_provider: "serpapi",
+                        });
+                      }}
+                    />
+                    <span>{t("options.serpApiKey")}</span>
+                  </label>
+                </div>
+                {(props.researchConfig.web_search_provider ?? "tavily") === "tavily" ? (
+                  <label className="form-field options-api-key-field">
+                    <span>
+                      <Key size={12} style={{ marginRight: 4, verticalAlign: "middle" }} />
+                      {t("options.tavilyApiKey")}
+                    </span>
+                    <div className="form-field-icon api-key-wrapper">
+                      <Key size={14} className="field-icon" />
+                      <input
+                        type={showTavilyKey ? "text" : "password"}
+                        value={props.researchConfig.tavily_api_key ?? ""}
+                        onChange={(event) => {
+                          props.onResearchConfigChange({
+                            ...props.researchConfig,
+                            tavily_api_key: event.target.value || undefined,
+                          });
+                        }}
+                        placeholder="tvly-..."
+                      />
+                      <button
+                        type="button"
+                        className="api-key-toggle"
+                        onClick={() => setShowTavilyKey((v) => !v)}
+                        tabIndex={-1}
+                      >
+                        {showTavilyKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                      </button>
+                    </div>
+                  </label>
+                ) : (
+                  <label className="form-field options-api-key-field">
+                    <span>
+                      <Key size={12} style={{ marginRight: 4, verticalAlign: "middle" }} />
+                      {t("options.serpApiKey")}
+                    </span>
+                    <div className="form-field-icon api-key-wrapper">
+                      <Key size={14} className="field-icon" />
+                      <input
+                        type={showSerpApiKey ? "text" : "password"}
+                        value={props.researchConfig.serpapi_key ?? ""}
+                        onChange={(event) => {
+                          props.onResearchConfigChange({
+                            ...props.researchConfig,
+                            serpapi_key: event.target.value || undefined,
+                          });
+                        }}
+                        placeholder="serp-..."
+                      />
+                      <button
+                        type="button"
+                        className="api-key-toggle"
+                        onClick={() => setShowSerpApiKey((v) => !v)}
+                        tabIndex={-1}
+                      >
+                        {showSerpApiKey ? <EyeOff size={14} /> : <Eye size={14} />}
+                      </button>
+                    </div>
+                  </label>
+                )}
+                {((props.researchConfig.web_search_provider ?? "tavily") === "tavily" && !props.researchConfig.tavily_api_key) ||
+                (props.researchConfig.web_search_provider === "serpapi" && !props.researchConfig.serpapi_key) ? (
                   <p className="research-warning">
                     <FlaskConical size={11} style={{ marginRight: 4, verticalAlign: "middle" }} />
                     {t("options.webSearchNoKey")}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -5,6 +5,8 @@ import { useGeneration } from "../../hooks/useGeneration";
 import { useLocale } from "../../i18n";
 import { translateStageStatus } from "../../lib/i18nStatus";
 
+const RECENT_HISTORY_DISPLAY_LIMIT = 8;
+
 interface SidebarProps {
   collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
@@ -13,20 +15,21 @@ interface SidebarProps {
 export function Sidebar({ collapsed = false, onCollapsedChange }: SidebarProps) {
   const { t, locale } = useLocale();
   const location = useLocation();
-  const { history, activeJobId, removeHistory, reset } = useGeneration();
+  const { history, activeJobId, removeHistory, reset, refreshHistoryStatuses } = useGeneration();
   const [confirmState, setConfirmState] = useState<{
     jobId: string;
     top: number;
     left: number;
   } | null>(null);
   const confirmRef = useRef<HTMLDivElement | null>(null);
+  const historyRefreshInFlightRef = useRef(false);
   const searchParams = new URLSearchParams(location.search);
   const links = [
     { to: "/", label: t("sidebar.overview"), icon: Home },
     { to: "/generate", label: t("sidebar.generationStudio"), icon: Layers3 },
     { to: "/logs", label: t("sidebar.logs"), icon: BarChart3 },
   ];
-  const recentHistory = history.slice(0, 5);
+  const recentHistory = history.slice(0, RECENT_HISTORY_DISPLAY_LIMIT);
   const currentResultJobId = searchParams.get("job");
   const currentGenerateJobId = searchParams.get("job");
   const isFreshEntryActive = location.pathname === "/generate" && searchParams.get("fresh") === "1";
@@ -60,6 +63,32 @@ export function Sidebar({ collapsed = false, onCollapsedChange }: SidebarProps) 
       document.removeEventListener("keydown", handleEscape);
     };
   }, [confirmState]);
+
+  useEffect(() => {
+    let stopped = false;
+
+    const refresh = async () => {
+      if (stopped || historyRefreshInFlightRef.current) {
+        return;
+      }
+      historyRefreshInFlightRef.current = true;
+      try {
+        await refreshHistoryStatuses();
+      } finally {
+        historyRefreshInFlightRef.current = false;
+      }
+    };
+
+    void refresh();
+    const timer = window.setInterval(() => {
+      void refresh();
+    }, 3000);
+
+    return () => {
+      stopped = true;
+      window.clearInterval(timer);
+    };
+  }, [refreshHistoryStatuses]);
 
   return (
     <aside className={`sidebar ${collapsed ? "sidebar-collapsed-panel" : ""}`}>

--- a/frontend/src/hooks/useGeneration.ts
+++ b/frontend/src/hooks/useGeneration.ts
@@ -20,11 +20,13 @@ import { openJobSocket } from "../lib/ws";
 
 type ConnectionStatus = "disconnected" | "connecting" | "connected";
 const FINAL_JOB_STATUSES = new Set(["complete", "error", "cancelled"]);
-const HISTORY_LIMIT = 8;
+const HISTORY_STORAGE_LIMIT = 50;
+const HISTORY_STATUS_SYNC_LIMIT = 8;
 const LEGACY_GENERATION_STORAGE_KEY = "paper-ppt-agent-generation-v1";
 const GENERATION_STORAGE_KEY = "paper-ppt-agent-generation-v2";
 const PERSISTED_LOG_LIMIT = 200;
 const LIVE_JOB_STORAGE_PREFIX = "paper-ppt-live-job:";
+const HISTORY_STATUS_SYNC_TIMEOUT_MS = 4000;
 
 /** Per-job seq deduper. Replays after reconnect can re-deliver events
  *  the client already processed; we drop anything with seq <= the last
@@ -113,6 +115,7 @@ interface GenerationState {
   cancelCurrentRun: () => Promise<void>;
   connect: (jobId: string) => void;
   hydrateResult: (jobId: string) => Promise<void>;
+  refreshHistoryStatuses: () => Promise<void>;
   resumeCurrentRun: (targetJobId?: string) => Promise<boolean>;
   selectSlide: (slide?: PreviewSlide) => void;
   syncHistory: (jobId?: string) => void;
@@ -167,7 +170,7 @@ function upsertHistoryItem(history: GenerationHistoryItem[], item: GenerationHis
     .sort((left, right) =>
       (right.createdAt ?? right.updatedAt).localeCompare(left.createdAt ?? left.updatedAt),
     )
-    .slice(0, HISTORY_LIMIT);
+    .slice(0, HISTORY_STORAGE_LIMIT);
 }
 
 function buildHistoryItemFromRun(history: GenerationHistoryItem[], run?: RunSnapshot) {
@@ -176,6 +179,7 @@ function buildHistoryItemFromRun(history: GenerationHistoryItem[], run?: RunSnap
   }
 
   const existing = history.find((entry) => entry.jobId === run.jobId);
+  const status = deriveRunStatus(run, existing);
   const slideCount = Math.max(
     run.slides.length,
     run.result?.slides.length ?? 0,
@@ -189,7 +193,7 @@ function buildHistoryItemFromRun(history: GenerationHistoryItem[], run?: RunSnap
     jobId: run.jobId,
     fileName: run.uploadSession?.file_info.name ?? existing?.fileName ?? run.jobId,
     sourceType: run.uploadSession?.file_info.source_type ?? existing?.sourceType,
-    status: run.result?.status ?? run.job?.status ?? existing?.status ?? "pending",
+    status,
     slideCount,
     createdAt: existing?.createdAt ?? existing?.updatedAt ?? now,
     updatedAt: now,
@@ -209,6 +213,26 @@ function buildHistoryItemFromRun(history: GenerationHistoryItem[], run?: RunSnap
     // previously in history. ``null`` clears the slot on success.
     error: run.error ?? existing?.error ?? null,
   } satisfies GenerationHistoryItem;
+}
+
+function deriveRunStatus(run: RunSnapshot, existing?: GenerationHistoryItem): string {
+  // JobStatus is the authoritative lifecycle state. PreviewResponse.status is
+  // only a rendering/result hint and may lag behind after cancellation or
+  // failure, so it must never overwrite a terminal job state in history.
+  const jobStatus = normalizeLifecycleStatus(run.job?.status);
+  if (jobStatus) {
+    return jobStatus;
+  }
+  const resultStatus = normalizeLifecycleStatus(run.result?.status);
+  if (resultStatus) {
+    return resultStatus;
+  }
+  return normalizeLifecycleStatus(existing?.status) ?? "pending";
+}
+
+function normalizeLifecycleStatus(status?: string | null): string | undefined {
+  const value = status?.toLowerCase().trim();
+  return value || undefined;
 }
 
 function pickSelectedSlide(slides: PreviewSlide[], selectedSlide?: PreviewSlide) {
@@ -404,6 +428,16 @@ function normalizeStoredRuns(runs?: Record<string, StoredRunSnapshot>) {
   return Object.fromEntries(
     Object.entries(runs).map(([jobId, run]) => [jobId, normalizeStoredRun(jobId, run)]),
   );
+}
+
+async function fetchJobStatusWithTimeout(jobId: string, timeoutMs = HISTORY_STATUS_SYNC_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchJobStatus(jobId, { signal: controller.signal });
+  } finally {
+    window.clearTimeout(timer);
+  }
 }
 
 export const useGeneration = create<GenerationState>()(
@@ -812,6 +846,62 @@ export const useGeneration = create<GenerationState>()(
           };
         });
         get().syncHistory(jobId);
+      },
+      async refreshHistoryStatuses() {
+        const candidates = get()
+          .history.filter((entry) => !FINAL_JOB_STATUSES.has(entry.status.toLowerCase()))
+          .slice(0, HISTORY_STATUS_SYNC_LIMIT);
+        if (!candidates.length) {
+          return;
+        }
+
+        await Promise.all(
+          candidates.map(async (entry) => {
+            try {
+              const job = await fetchJobStatusWithTimeout(entry.jobId);
+              set((state) => {
+                const currentRun =
+                  state.runs[entry.jobId] ??
+                  createRunSnapshot(entry.jobId, {
+                    job: buildStoredJob(entry),
+                    error: entry.error ?? undefined,
+                  });
+                const updatedRun: RunSnapshot = {
+                  ...currentRun,
+                  job,
+                  error: job.error ?? undefined,
+                  connectionStatus: FINAL_JOB_STATUSES.has(job.status)
+                    ? "disconnected"
+                    : currentRun.connectionStatus,
+                };
+                const nextItem = buildHistoryItemFromRun(state.history, updatedRun);
+                return {
+                  ...(state.jobId === entry.jobId ? applyRunToCurrent(updatedRun) : {}),
+                  runs: {
+                    ...state.runs,
+                    [entry.jobId]: updatedRun,
+                  },
+                  history: nextItem ? upsertHistoryItem(state.history, nextItem) : state.history,
+                  activeJobId:
+                    state.activeJobId === entry.jobId && FINAL_JOB_STATUSES.has(job.status)
+                      ? undefined
+                      : state.activeJobId,
+                };
+              });
+              if (job.status === "complete") {
+                void get().hydrateResult(entry.jobId).catch(() => undefined);
+              }
+            } catch (error) {
+              if (isNotFoundError(error)) {
+                try {
+                  sessionStorage.removeItem(`${LIVE_JOB_STORAGE_PREFIX}${entry.jobId}`);
+                } catch {
+                  /* noop */
+                }
+              }
+            }
+          }),
+        );
       },
       async resumeCurrentRun(targetJobId) {
         const currentJobId = targetJobId ?? get().activeJobId ?? get().jobId;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -160,8 +160,8 @@ export async function generatePresentation(
   });
 }
 
-export async function fetchJobStatus(jobId: string): Promise<JobStatus> {
-  return request<JobStatus>(`/api/status/${jobId}`);
+export async function fetchJobStatus(jobId: string, init?: RequestInit): Promise<JobStatus> {
+  return request<JobStatus>(`/api/status/${jobId}`, init);
 }
 
 export async function cancelJob(jobId: string): Promise<CancelJobResponse> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -53,6 +53,7 @@ export interface ResearchConfig {
   semantic_scholar_enabled?: boolean;
   web_search_enabled?: boolean;
   semantic_scholar_api_key?: string;
+  web_search_provider?: "tavily" | "serpapi";
   tavily_api_key?: string;
   serpapi_key?: string;
   max_results_per_source?: number;

--- a/frontend/src/pages/GeneratePage.tsx
+++ b/frontend/src/pages/GeneratePage.tsx
@@ -174,6 +174,7 @@ export function GeneratePage() {
         const parsed = JSON.parse(saved) as Record<string, string>;
         return {
           ...base,
+          web_search_provider: base.web_search_provider || (parsed.web_search_provider as "tavily" | "serpapi" | undefined) || undefined,
           semantic_scholar_api_key: base.semantic_scholar_api_key || parsed.semantic_scholar_api_key || undefined,
           tavily_api_key: base.tavily_api_key || parsed.tavily_api_key || undefined,
           serpapi_key: base.serpapi_key || parsed.serpapi_key || undefined,
@@ -336,6 +337,7 @@ export function GeneratePage() {
       const incoming = options.research_config ?? {};
       return {
         ...incoming,
+        web_search_provider: incoming.web_search_provider || prev.web_search_provider,
         semantic_scholar_api_key: incoming.semantic_scholar_api_key || prev.semantic_scholar_api_key,
         tavily_api_key: incoming.tavily_api_key || prev.tavily_api_key,
         serpapi_key: incoming.serpapi_key || prev.serpapi_key,
@@ -358,6 +360,7 @@ export function GeneratePage() {
       const existingRaw = window.localStorage.getItem(RESEARCH_KEYS_STORAGE);
       const existing = existingRaw ? (JSON.parse(existingRaw) as Record<string, string>) : {};
       const next = {
+        web_search_provider: researchConfig.web_search_provider || existing.web_search_provider || "tavily",
         semantic_scholar_api_key:
           researchConfig.semantic_scholar_api_key || existing.semantic_scholar_api_key || "",
         tavily_api_key: researchConfig.tavily_api_key || existing.tavily_api_key || "",
@@ -365,7 +368,7 @@ export function GeneratePage() {
       };
       window.localStorage.setItem(RESEARCH_KEYS_STORAGE, JSON.stringify(next));
     } catch { /* noop */ }
-  }, [researchConfig.semantic_scholar_api_key, researchConfig.tavily_api_key, researchConfig.serpapi_key]);
+  }, [researchConfig.web_search_provider, researchConfig.semantic_scholar_api_key, researchConfig.tavily_api_key, researchConfig.serpapi_key]);
 
   useEffect(() => {
     if (targetJobId) {

--- a/frontend/src/pages/GeneratePage.tsx
+++ b/frontend/src/pages/GeneratePage.tsx
@@ -123,6 +123,7 @@ export function GeneratePage() {
     error,
     currentRunConfig,
     history,
+    runs,
     loadProviders,
     uploadFile,
     startGeneration,
@@ -195,24 +196,31 @@ export function GeneratePage() {
     ? history.find((entry) => entry.jobId === targetJobId)
     : undefined;
   const selectedRunConfig = useMemo(() => {
+    if (targetJobId) {
+      const targetRunConfig = runs[targetJobId]?.currentRunConfig;
+      if (targetRunConfig) {
+        return targetRunConfig;
+      }
+      if (
+        targetHistoryEntry?.provider &&
+        targetHistoryEntry.model &&
+        targetHistoryEntry.options
+      ) {
+        return {
+          provider: targetHistoryEntry.provider,
+          model: targetHistoryEntry.model,
+          baseUrl: targetHistoryEntry.baseUrl ?? undefined,
+          options: targetHistoryEntry.options,
+          parentJobId: targetHistoryEntry.parentJobId ?? null,
+        };
+      }
+      return undefined;
+    }
     if (currentRunConfig) {
       return currentRunConfig;
     }
-    if (
-      targetHistoryEntry?.provider &&
-      targetHistoryEntry.model &&
-      targetHistoryEntry.options
-    ) {
-      return {
-        provider: targetHistoryEntry.provider,
-        model: targetHistoryEntry.model,
-        baseUrl: targetHistoryEntry.baseUrl ?? undefined,
-        options: targetHistoryEntry.options,
-        parentJobId: targetHistoryEntry.parentJobId ?? null,
-      };
-    }
     return undefined;
-  }, [currentRunConfig, targetHistoryEntry]);
+  }, [currentRunConfig, runs, targetHistoryEntry, targetJobId]);
   const canCancelCurrentRun = Boolean(
     jobId &&
       job &&

--- a/frontend/src/pages/GeneratePage.tsx
+++ b/frontend/src/pages/GeneratePage.tsx
@@ -324,7 +324,15 @@ export function GeneratePage() {
     setEnableVisualCritic(Boolean(options.enable_visual_critic));
     setEnableIcon(options.enable_icon !== false);
     setEnableIconRag(options.enable_icon_rag !== false);
-    setResearchConfig(options.research_config ?? {});
+    setResearchConfig((prev) => {
+      const incoming = options.research_config ?? {};
+      return {
+        ...incoming,
+        semantic_scholar_api_key: incoming.semantic_scholar_api_key || prev.semantic_scholar_api_key,
+        tavily_api_key: incoming.tavily_api_key || prev.tavily_api_key,
+        serpapi_key: incoming.serpapi_key || prev.serpapi_key,
+      };
+    });
     setGeminiApiKey(options.gemini_api_key ?? "");
     setTemplateId(options.template_id ?? "");
   }, [selectedRunConfig, targetJobId]);
@@ -339,12 +347,15 @@ export function GeneratePage() {
 
   useEffect(() => {
     try {
-      const keys = {
-        semantic_scholar_api_key: researchConfig.semantic_scholar_api_key ?? "",
-        tavily_api_key: researchConfig.tavily_api_key ?? "",
-        serpapi_key: researchConfig.serpapi_key ?? "",
+      const existingRaw = window.localStorage.getItem(RESEARCH_KEYS_STORAGE);
+      const existing = existingRaw ? (JSON.parse(existingRaw) as Record<string, string>) : {};
+      const next = {
+        semantic_scholar_api_key:
+          researchConfig.semantic_scholar_api_key || existing.semantic_scholar_api_key || "",
+        tavily_api_key: researchConfig.tavily_api_key || existing.tavily_api_key || "",
+        serpapi_key: researchConfig.serpapi_key || existing.serpapi_key || "",
       };
-      window.localStorage.setItem(RESEARCH_KEYS_STORAGE, JSON.stringify(keys));
+      window.localStorage.setItem(RESEARCH_KEYS_STORAGE, JSON.stringify(next));
     } catch { /* noop */ }
   }, [researchConfig.semantic_scholar_api_key, researchConfig.tavily_api_key, researchConfig.serpapi_key]);
 

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -434,7 +434,7 @@ export function ResultPage() {
       <section className="result-summary">
         <div className="metric-stripe">
           <span>{t("result.status")}</span>
-          <strong>{formatStatusLabel(result?.status ?? job?.status ?? historyEntry?.status, locale, t("common.unknown"))}</strong>
+          <strong>{formatStatusLabel(job?.status ?? result?.status ?? historyEntry?.status, locale, t("common.unknown"))}</strong>
         </div>
         <div className="metric-stripe">
           <span>{t("result.slides")}</span>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1637,6 +1637,28 @@ html[lang="zh-CN"] .panel-title {
   gap: 0.5rem;
 }
 
+.research-provider-select {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.research-provider-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.research-provider-option input[type="radio"] {
+  accent-color: var(--accent);
+  margin: 0;
+  width: 14px;
+  height: 14px;
+}
+
 /* ── External-research enrichment summary ─────────────────────────── */
 .enrichment-summary {
   margin-top: 0.85rem;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 
 from backend.app import create_app
 from backend.config import settings
+import backend.runtime.scheduler as scheduler_module
 from backend.session.manager import session_manager
 
 
@@ -25,6 +26,7 @@ def workspace_tmp() -> Path:
 
 @pytest.fixture(autouse=True)
 def isolate_state(workspace_tmp: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(scheduler_module, "_scheduler", None)
     monkeypatch.setattr(settings, "runtime_dir", workspace_tmp / ".runtime")
     settings.runtime_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(session_manager, "_state_file", settings.runtime_dir / "session_state.json")
@@ -33,6 +35,7 @@ def isolate_state(workspace_tmp: Path, monkeypatch: pytest.MonkeyPatch):
     session_manager.clear()
     yield
     session_manager.clear()
+    monkeypatch.setattr(scheduler_module, "_scheduler", None)
 
 
 @pytest.fixture

--- a/tests/test_api_generate.py
+++ b/tests/test_api_generate.py
@@ -174,10 +174,17 @@ def test_preview_and_websocket_receive_slide_events(client, pdf_bytes: bytes, mo
         assert first["type"] == "progress"
         assert first["job_id"] == job_id
 
-    time.sleep(0.01)
-    preview_response = client.get(f"/api/preview/{job_id}")
-    assert preview_response.status_code == 200
-    slides = preview_response.json()["slides"]
+    deadline = time.time() + 1.0
+    slides = []
+    preview_response = None
+    while time.time() < deadline:
+        preview_response = client.get(f"/api/preview/{job_id}")
+        assert preview_response.status_code == 200
+        slides = preview_response.json()["slides"]
+        if slides:
+            break
+        time.sleep(0.01)
+    assert preview_response is not None
     assert len(slides) == 1
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+
+from backend.runtime.scheduler import Scheduler
+
+
+async def _wait_until(predicate, timeout: float = 1.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition was not met before timeout")
+
+
+def test_scheduler_starts_jobs_immediately_without_queueing():
+    async def scenario() -> None:
+        scheduler = Scheduler(max_concurrent=1, queue_capacity=1)
+        started: list[str] = []
+        release = asyncio.Event()
+
+        async def job(name: str) -> None:
+            started.append(name)
+            await release.wait()
+
+        await scheduler.start()
+        try:
+            first_size = await scheduler.submit("first", lambda: job("first"))
+            second_size = await scheduler.submit("second", lambda: job("second"))
+
+            assert first_size == 0
+            assert second_size == 0
+            await _wait_until(lambda: set(started) == {"first", "second"})
+            assert scheduler.queue_size == 0
+            assert scheduler.running_count == 2
+        finally:
+            release.set()
+            await scheduler.shutdown(timeout=0.1)
+
+    asyncio.run(scenario())
+
+
+def test_scheduler_cancel_only_targets_requested_job():
+    async def scenario() -> None:
+        scheduler = Scheduler()
+        release = asyncio.Event()
+        started: list[str] = []
+        cancelled: list[str] = []
+        completed: list[str] = []
+
+        async def job(name: str) -> None:
+            try:
+                started.append(name)
+                await release.wait()
+                completed.append(name)
+            except asyncio.CancelledError:
+                cancelled.append(name)
+                raise
+
+        await scheduler.start()
+        try:
+            await scheduler.submit("first", lambda: job("first"))
+            await scheduler.submit("second", lambda: job("second"))
+            await _wait_until(lambda: set(started) == {"first", "second"})
+
+            assert scheduler.cancel("first") is True
+            await _wait_until(lambda: cancelled == ["first"])
+            assert scheduler.is_active("second") is True
+            release.set()
+            await _wait_until(lambda: completed == ["second"])
+        finally:
+            release.set()
+            await scheduler.shutdown(timeout=0.1)
+
+    asyncio.run(scenario())

--- a/tests/test_strategist_agent.py
+++ b/tests/test_strategist_agent.py
@@ -191,6 +191,26 @@ def test_design_spec_validation_rejects_missing_icon_asset() -> None:
     assert "chunk/alert-triangle" in error
 
 
+@pytest.mark.asyncio
+async def test_icon_rag_candidates_skip_missing_local_assets(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeIndex:
+        is_available = True
+
+        def search(self, query: str, *, lib: str, k: int) -> list[dict]:
+            return [
+                {"path": "chunk/scale", "score": 0.99, "category": "metric", "tags": ["scale"]},
+                {"path": "chunk/ruler", "score": 0.88, "category": "metric", "tags": ["measure"]},
+            ]
+
+    monkeypatch.setattr(strategist_agent, "get_icon_index", lambda: _FakeIndex())
+    monkeypatch.setattr(strategist_agent, "_icon_asset_exists", lambda path: path == "chunk/ruler")
+
+    block = await strategist_agent._retrieve_icon_candidates("## Measurement\n\n**scale**", "chunk")
+
+    assert "`chunk/ruler`" in block
+    assert "chunk/scale" not in block
+
+
 def test_offline_icon_candidates_are_verified_and_semantic() -> None:
     block = strategist_agent._offline_icon_candidates_block("chunk")
 


### PR DESCRIPTION
## Summary
- Fix Tavily/SerpAPI keys being wiped on remount and history restore
- Introduce async runtime (offload pool, event bus, subprocess helpers) so a running job no longer freezes the API
- Replace priority queue scheduler with immediate per-job runner
- Make Tavily/SerpAPI web search provider a mutually exclusive radio with Eye/EyeOff toggle on all API key inputs

## Test plan
- [ ] Verify API keys persist across page remount and history restore
- [ ] Start a generation and confirm API remains responsive (healthcheck, new submissions)
- [ ] Switch between Tavily/SerpAPI radio and confirm only the selected provider's key is shown
- [ ] Toggle Eye/EyeOff on Gemini, Semantic Scholar, Tavily, and SerpAPI key fields
- [ ] Run `pytest tests/` and confirm all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)