### PR TITLE
[codex] Fix responsive studio layout and TeX parsing

### DIFF
--- a/backend/parser/latex_parser.py
+++ b/backend/parser/latex_parser.py
@@ -143,42 +143,85 @@ class LaTeXParser(PaperParser):
             figures_dir=images_dir,
         )
 
-    def _resolve_includes(self, tex_path: Path, base_dir: Path, depth: int = 0) -> str:
+    def _resolve_includes(
+        self,
+        tex_path: Path,
+        base_dir: Path,
+        depth: int = 0,
+        visited: set[Path] | None = None,
+        root_path: Path | None = None,
+    ) -> str:
         r"""Recursively resolve \input{} and \include{} directives."""
-        if depth > 10:  # Prevent infinite recursion
+        if depth > 20:  # Prevent infinite recursion
             return ""
 
+        visited = visited or set()
         try:
-            content = tex_path.read_text(encoding="utf-8", errors="ignore")
+            resolved_tex_path = tex_path.resolve()
+            project_root = base_dir.resolve()
+        except OSError:
+            return ""
+
+        if resolved_tex_path in visited:
+            return ""
+        visited.add(resolved_tex_path)
+        root_path = root_path or resolved_tex_path
+
+        try:
+            content = resolved_tex_path.read_text(encoding="utf-8", errors="ignore")
         except Exception:
             return ""
 
+        content = self._strip_latex_comments(content)
+        if resolved_tex_path != root_path:
+            body = self._extract_document_body(content)
+            if body:
+                content = body
+
         def replace_include(match: re.Match) -> str:
-            filename = match.group(1)
-            if not filename.endswith(".tex"):
-                filename += ".tex"
-            included_path = base_dir / filename
-            if included_path.exists():
-                return self._resolve_includes(included_path, base_dir, depth + 1)
+            raw_filename = match.group(1).strip()
+            if not raw_filename or raw_filename.startswith("\\"):
+                return match.group(0)
+
+            filename = raw_filename if raw_filename.endswith(".tex") else f"{raw_filename}.tex"
+            search_dirs = [resolved_tex_path.parent, project_root]
+            for search_dir in search_dirs:
+                included_path = (search_dir / filename).resolve()
+                try:
+                    included_path.relative_to(project_root)
+                except ValueError:
+                    continue
+                if included_path.exists():
+                    return self._resolve_includes(
+                        included_path,
+                        project_root,
+                        depth + 1,
+                        visited,
+                        root_path,
+                    )
             return match.group(0)  # Keep original if file not found
 
         # Resolve \input{...} and \include{...}
-        content = re.sub(r"\\input\{([^}]+)\}", replace_include, content)
-        content = re.sub(r"\\include\{([^}]+)\}", replace_include, content)
+        content = re.sub(r"\\(?:input|include)\s*\{([^}]+)\}", replace_include, content)
 
         return content
 
     def _extract_title(self, content: str) -> str:
-        match = re.search(r"\\title\{([^}]+)\}", content)
-        if match:
-            return self._clean_latex(match.group(1))
+        title = self._extract_command_argument(content, "title")
+        if title:
+            return self._clean_latex(title)
+
+        setup_title = self._extract_setup_title(content)
+        if setup_title:
+            return self._clean_latex(setup_title)
+
         return "Untitled"
 
     def _extract_authors(self, content: str) -> list[str]:
-        match = re.search(r"\\author\{(.+?)\}", content, re.DOTALL)
-        if not match:
+        author_arg = self._extract_command_argument(content, "author")
+        if not author_arg:
             return []
-        raw = self._clean_latex(match.group(1))
+        raw = self._clean_latex(author_arg)
         # Split on \and, commas, or newlines
         parts = re.split(r"\\and|,|\n", raw)
         return [a.strip() for a in parts if a.strip()]
@@ -380,16 +423,31 @@ class LaTeXParser(PaperParser):
     def _basic_latex_to_markdown(self, content: str) -> str:
         """Basic LaTeX to Markdown conversion without pandoc."""
         # Extract document body
-        match = re.search(
-            r"\\begin\{document\}(.+?)\\end\{document\}", content, re.DOTALL
-        )
-        if match:
-            content = match.group(1)
+        body = self._extract_document_body(content)
+        if body:
+            content = body
+
+        content = self._strip_latex_comments(content)
 
         # Convert sections
-        content = re.sub(r"\\section\{([^}]+)\}", r"## \1", content)
-        content = re.sub(r"\\subsection\{([^}]+)\}", r"### \1", content)
-        content = re.sub(r"\\subsubsection\{([^}]+)\}", r"#### \1", content)
+        heading_levels = {
+            "part": "##",
+            "chapter": "##",
+            "section": "##",
+            "subsection": "###",
+            "subsubsection": "####",
+        }
+
+        def replace_heading(match: re.Match) -> str:
+            command = match.group(1)
+            title = self._clean_latex(match.group(2))
+            return f"\n{heading_levels[command]} {title}\n\n"
+
+        content = re.sub(
+            r"\\(part|chapter|section|subsection|subsubsection)\*?\s*(?:\[[^\]]*\])?\{([^{}]+)\}",
+            replace_heading,
+            content,
+        )
 
         # Convert emphasis
         content = re.sub(r"\\textbf\{([^}]+)\}", r"**\1**", content)
@@ -409,7 +467,7 @@ class LaTeXParser(PaperParser):
         content = re.sub(r"\\bibliographystyle\{[^}]+\}", "", content)
         content = re.sub(r"\\bibliography\{[^}]+\}", "", content)
 
-        return self._clean_latex(content)
+        return self._clean_latex_block(content)
 
     def _parse_sections(
         self, markdown: str, figures: list[PaperFigure]
@@ -487,11 +545,96 @@ class LaTeXParser(PaperParser):
             pass
         return refs
 
+    def _strip_latex_comments(self, text: str) -> str:
+        """Remove unescaped LaTeX comments while preserving line structure."""
+        lines: list[str] = []
+        for line in text.splitlines():
+            cut_at: int | None = None
+            for idx, char in enumerate(line):
+                if char != "%":
+                    continue
+                slash_count = 0
+                cursor = idx - 1
+                while cursor >= 0 and line[cursor] == "\\":
+                    slash_count += 1
+                    cursor -= 1
+                if slash_count % 2 == 0:
+                    cut_at = idx
+                    break
+            lines.append(line[:cut_at] if cut_at is not None else line)
+        return "\n".join(lines)
+
+    def _extract_document_body(self, content: str) -> str:
+        match = re.search(
+            r"\\begin\{document\}(.+?)\\end\{document\}", content, re.DOTALL
+        )
+        return match.group(1) if match else ""
+
+    def _extract_command_argument(self, content: str, command: str) -> str:
+        pattern = re.compile(rf"\\{re.escape(command)}\*?\s*(?:\[[^\]]*\]\s*)?\{{")
+        match = pattern.search(content)
+        if not match:
+            return ""
+        return self._read_braced_content(content, match.end() - 1)
+
+    def _extract_setup_title(self, content: str) -> str:
+        for match in re.finditer(r"\\[a-zA-Z@]*setup\s*\{", content):
+            setup_body = self._read_braced_content(content, match.end() - 1)
+            title = self._extract_keyed_braced_value(setup_body, "title")
+            if title:
+                return title
+        return ""
+
+    def _extract_keyed_braced_value(self, content: str, key: str) -> str:
+        for match in re.finditer(rf"\b{re.escape(key)}\s*=", content):
+            cursor = match.end()
+            while cursor < len(content) and content[cursor].isspace():
+                cursor += 1
+            if cursor < len(content) and content[cursor] == "{":
+                return self._read_braced_content(content, cursor)
+        return ""
+
+    def _read_braced_content(self, text: str, open_brace_index: int) -> str:
+        if open_brace_index >= len(text) or text[open_brace_index] != "{":
+            return ""
+        depth = 0
+        start = open_brace_index + 1
+        for idx in range(open_brace_index, len(text)):
+            char = text[idx]
+            escaped = idx > 0 and text[idx - 1] == "\\"
+            if escaped:
+                continue
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start:idx]
+        return ""
+
+    def _clean_latex_block(self, text: str) -> str:
+        """Clean LaTeX text while preserving line breaks for Markdown headings."""
+        cleaned_lines: list[str] = []
+        previous_blank = False
+        for raw_line in text.splitlines():
+            cleaned = self._clean_latex(raw_line)
+            if cleaned:
+                cleaned_lines.append(cleaned)
+                previous_blank = False
+            elif not previous_blank and cleaned_lines:
+                cleaned_lines.append("")
+                previous_blank = True
+        return "\n".join(cleaned_lines).strip()
+
     def _clean_latex(self, text: str) -> str:
         """Remove common LaTeX commands from text."""
+        text = re.sub(r"~", " ", text)
+        text = re.sub(r"\\(?:cite|citep|citet|ref|eqref|label)\*?(?:\[[^\]]*\])?\{[^}]*\}", "", text)
+        text = re.sub(r"\\(?:begin|end)\{[^}]+\}", "", text)
         text = re.sub(r"\\[a-zA-Z]+\{([^}]*)\}", r"\1", text)
         text = re.sub(r"\\[a-zA-Z]+\[[^\]]*\]", "", text)
         text = re.sub(r"\\[a-zA-Z]+", "", text)
+        text = re.sub(r"\\([{}%&_#])", r"\1", text)
         text = re.sub(r"[{}]", "", text)
         text = re.sub(r"\s+", " ", text)
         return text.strip()

--- a/frontend/src/components/config/OptionsPanel.tsx
+++ b/frontend/src/components/config/OptionsPanel.tsx
@@ -266,9 +266,6 @@ export function OptionsPanel(props: OptionsPanelProps) {
             </span>
             <span className="visual-qa-copy">
               <span className="visual-qa-name">{t("options.parallelGeneration")}</span>
-              <span className="visual-qa-mode">
-                {t(`options.generationMode.${props.generationMode}`)}
-              </span>
               <span className="visual-qa-experimental parallel-experimental-badge">{t("common.experimental")}</span>
             </span>
             <ConfigHelp text={t("options.parallelGenerationTooltip")} />

--- a/frontend/src/components/template/ProgressView.tsx
+++ b/frontend/src/components/template/ProgressView.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { AlertTriangle, CheckCircle2, CircleDashed, Loader2, RotateCcw, SkipForward } from "lucide-react";
 
-import { useLocale } from "../../i18n";
+import { useLocale, type Locale } from "../../i18n";
+import { translateTemplateImportMessage } from "../../lib/i18nStatus";
 import type { ImportStatus } from "../../lib/types";
 
 export interface ProgressViewProps {
@@ -33,7 +34,7 @@ const DIRECT_STEP_ORDER = ["uploaded", "analyzing", "rendering", "review"] as co
  * `error_kind` description plus a "Retry this stage" button (Req 1.5/1.6).
  */
 export function ProgressView({ status, onRetry, mode = "llm" }: ProgressViewProps) {
-  const { t } = useLocale();
+  const { t, locale } = useLocale();
   const [now, setNow] = useState(() => Date.now() / 1000);
 
   // Tick every second so "active" elapsed time triggers the >10s message.
@@ -57,7 +58,7 @@ export function ProgressView({ status, onRetry, mode = "llm" }: ProgressViewProp
       <div>
         <div className="mb-2 flex items-center justify-between text-sm">
           <strong style={{ color: "var(--ti-text)" }}>
-            {status.message || t("template.processing")}
+            {translateTemplateImportMessage(status.message, locale) || t("template.processing")}
           </strong>
           <span style={{ color: "var(--ti-muted)" }}>{overallPct}%</span>
         </div>
@@ -85,9 +86,9 @@ export function ProgressView({ status, onRetry, mode = "llm" }: ProgressViewProp
         ))}
       </div>
 
-      <ActiveDetail steps={steps} now={now} t={t} />
+      <ActiveDetail steps={steps} now={now} t={t} locale={locale} />
 
-      <ErrorPanel status={status} steps={steps} onRetry={onRetry} t={t} />
+      <ErrorPanel status={status} steps={steps} onRetry={onRetry} t={t} locale={locale} />
     </div>
   );
 }
@@ -169,10 +170,12 @@ function ActiveDetail({
   steps,
   now,
   t,
+  locale,
 }: {
   steps: StepLike[];
   now: number;
   t: (key: string) => string;
+  locale: Locale;
 }) {
   const active = steps.find((s) => s.status === "active");
   if (!active) return null;
@@ -195,7 +198,7 @@ function ActiveDetail({
       <span className="mr-2 font-semibold" style={{ color: "var(--ti-accent)" }}>
         {label}
       </span>
-      <span>{active.message}</span>
+      <span>{translateTemplateImportMessage(active.message, locale)}</span>
     </div>
   );
 }
@@ -205,11 +208,13 @@ function ErrorPanel({
   steps,
   onRetry,
   t,
+  locale,
 }: {
   status: ImportStatus;
   steps: StepLike[];
   onRetry: (stepId: string) => void;
   t: (key: string) => string;
+  locale: Locale;
 }) {
   const errored = steps.find((s) => s.status === "error");
   const topLevelError = status.status === "error" ? status.error : null;
@@ -217,7 +222,7 @@ function ErrorPanel({
 
   const stepId = errored?.id ?? "";
   const errorKind = errored?.error_kind || inferErrorKind(stepId);
-  const message = errored?.error || errored?.message || topLevelError || t("template.importError");
+  const message = translateTemplateImportMessage(errored?.error || errored?.message || topLevelError, locale) || t("template.importError");
 
   return (
     <div

--- a/frontend/src/lib/i18nStatus.ts
+++ b/frontend/src/lib/i18nStatus.ts
@@ -90,7 +90,9 @@ export function translateJobMessage(message: string | undefined, locale: Locale)
     "Enriching with external research APIs...": "正在通过外部研究 API 补充信息...",
     "Querying external research sources...": "正在查询外部信息源...",
     "External research returned no results": "外部研究未返回结果",
+    "Preparing paper brief": "正在准备论文概要",
     "Generating manuscript": "正在生成讲稿",
+    "Generating manuscript from brief": "正在根据论文概要生成讲稿",
     "Pass 1/4 — Deep reading": "第 1/4 轮 — 深度研读",
     "Pass 2/4 — Narrative arc": "第 2/4 轮 — 叙事弧线",
     "Pass 3/4 — Manuscript": "第 3/4 轮 — 讲稿生成",
@@ -123,7 +125,9 @@ export function translateJobMessage(message: string | undefined, locale: Locale)
 
   const parsedMatch = message.match(/^Parsed:\s*(.+)$/);
   if (parsedMatch) {
-    return `已解析：${parsedMatch[1]}`;
+    const title = parsedMatch[1].replace(/\s+\(layout fallback used\)$/, "");
+    const fallbackUsed = title !== parsedMatch[1];
+    return `已解析：${title}${fallbackUsed ? "（已使用版面兜底解析）" : ""}`;
   }
 
   const generatedSlideMatch = message.match(/^Generated slide (\d+)\/(\d+)$/);
@@ -176,6 +180,59 @@ export function translateJobMessage(message: string | undefined, locale: Locale)
   }
 
   return message;
+}
+
+export function translateTemplateImportMessage(message: string | undefined | null, locale: Locale): string | undefined {
+  if (!message || locale !== "zh") {
+    return message ?? undefined;
+  }
+
+  const exact: Record<string, string> = {
+    "Agent mode workspace is ready.": "智能体模式工作区已准备好。",
+    "Direct import workspace is ready.": "直接导入工作区已准备好。",
+    "Claude Code is installed and the Agent SDK is available.": "已安装 Claude Code，Agent SDK 可用。",
+    "Claude Code CLI and claude-agent-sdk are not available in the backend environment.": "后端环境中 Claude Code CLI 和 claude-agent-sdk 均不可用。",
+    "Claude Code CLI is not installed or not on PATH.": "Claude Code CLI 未安装或不在 PATH 中。",
+    "Agent job not found.": "未找到智能体任务。",
+    "Upload received.": "已收到上传文件。",
+    "Template import requires an LLM model configuration.": "模板导入需要先配置 LLM 模型。",
+    "Optimizing template draft with feedback.": "正在根据反馈优化模板草稿。",
+    "Running intelligent template analysis.": "正在进行智能模板分析。",
+    "LLM template analysis failed.": "LLM 模板分析失败。",
+    "Review page types and reusable assets before registering the template.": "注册模板前请检查页面类型和可复用资产。",
+    "Generating Direct template design_spec.md with LLM.": "正在使用 LLM 生成直接导入模板的 design_spec.md。",
+    "Direct template design_spec.md generation failed.": "直接导入模板的 design_spec.md 生成失败。",
+    "Analyzing PPTX structure.": "正在分析 PPTX 结构。",
+    "Rendering slides to SVG.": "正在将幻灯片渲染为 SVG。",
+    "Cleaning SVGs and detecting reusable assets.": "正在清理 SVG 并检测可复用资产。",
+    "Generating a rule-based template draft with placeholders.": "正在生成带占位符的规则模板草稿。",
+    "Waiting for mandatory LLM template analysis.": "正在等待必需的 LLM 模板分析。",
+    "Template import failed.": "模板导入失败。",
+    "Registering reviewed template.": "正在注册已审核模板。",
+    "Template registered.": "模板已注册。",
+    "Direct template validation failed.": "直接导入模板校验失败。",
+    "Registering direct template.": "正在注册直接导入模板。",
+    "Direct template registered.": "直接导入模板已注册。",
+    "Agent task queued.": "智能体任务已排队。",
+    "Starting Claude Agent.": "正在启动 Claude Agent。",
+    "Agent running.": "智能体正在运行。",
+    "Agent stream interrupted; resuming the session.": "智能体流中断，正在恢复会话。",
+    "Template artifacts updated.": "模板产物已更新。",
+    "Agent task complete.": "智能体任务已完成。",
+    "Agent task cancelled.": "智能体任务已取消。",
+    "Agent task failed.": "智能体任务失败。",
+    "Template already installed.": "模板已安装。",
+    "Direct import uses the five uploaded slides as-is; no templateization was applied.": "直接导入将按原样使用上传的 5 页幻灯片，不执行模板化处理。",
+    "Direct import installed the five uploaded slides as-is; no templateization was applied.": "直接导入已按原样安装上传的 5 页幻灯片，未执行模板化处理。",
+    "Agent templateization has not produced a complete five-page template pack yet.": "智能体尚未产出完整的五页模板包。",
+    "Preview includes Agent-authored template SVG outputs.": "预览包含智能体生成的模板 SVG 输出。",
+    "Template was rebuilt from PPTist deck JSON because no server SVG renderer was available.": "由于服务器 SVG 渲染器不可用，模板已从 PPTist deck JSON 重建。",
+    "Preview was rebuilt from the saved PPTist deck because server SVG rendering is unavailable.": "由于服务器 SVG 渲染不可用，预览已从保存的 PPTist deck 重建。",
+    "Skipped until the user saves a PPTist deck.": "已跳过，等待用户保存 PPTist deck。",
+    "User/Agent workflow owns template planning.": "模板规划由用户/智能体工作流接管。",
+  };
+
+  return exact[message] ?? message;
 }
 
 function translateEnrichmentToken(value: string): string {

--- a/frontend/src/pages/GeneratePage.tsx
+++ b/frontend/src/pages/GeneratePage.tsx
@@ -247,6 +247,7 @@ export function GeneratePage() {
   const [templates, setTemplates] = useState<TemplateInfo[]>([]);
   const [cancelLoading, setCancelLoading] = useState(false);
   const [secondaryPanel, setSecondaryPanel] = useState<SecondaryPanel | null>(null);
+  const [workspaceSideTab, setWorkspaceSideTab] = useState<"sources" | "config">("sources");
   const freshRequested = searchParams.get("fresh") === "1";
   const targetJobId = searchParams.get("job") ?? undefined;
   const targetHistoryEntry = targetJobId
@@ -584,7 +585,29 @@ export function GeneratePage() {
 
   return (
     <Layout showSidebar={false} contentClassName="studio-page scholarly-workspace-page">
-      <section className="scholarly-workspace">
+      <section className="scholarly-workspace" data-side-tab={workspaceSideTab}>
+        <div className="workspace-side-tabs" role="tablist" aria-label={`${t("source.title")} / ${t("config.title")}`}>
+          <button
+            type="button"
+            className={`workspace-side-tab ${workspaceSideTab === "sources" ? "workspace-side-tab-active" : ""}`}
+            aria-selected={workspaceSideTab === "sources"}
+            role="tab"
+            onClick={() => setWorkspaceSideTab("sources")}
+          >
+            <Database size={16} />
+            <span>{t("source.title")}</span>
+          </button>
+          <button
+            type="button"
+            className={`workspace-side-tab ${workspaceSideTab === "config" ? "workspace-side-tab-active" : ""}`}
+            aria-selected={workspaceSideTab === "config"}
+            role="tab"
+            onClick={() => setWorkspaceSideTab("config")}
+          >
+            <Settings2 size={16} />
+            <span>{t("config.title")}</span>
+          </button>
+        </div>
         <SourcesPanel
           uploadSession={uploadSession}
           job={job}

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -112,6 +112,7 @@ export function ResultPage() {
   // ── refine state ───────────────────────────────────────────────────────────
   type SecondaryPanel = "log" | "critic";
   const [secondaryPanel, setSecondaryPanel] = useState<SecondaryPanel | null>(null);
+  const [workspaceSideTab, setWorkspaceSideTab] = useState<"sources" | "config">("sources");
   const [feedback, setFeedback] = useState("");
   const [refineLoading, setRefineLoading] = useState(false);
   const [cancelLoading, setCancelLoading] = useState(false);
@@ -501,7 +502,29 @@ export function ResultPage() {
 
   return (
     <Layout showSidebar={false} contentClassName="studio-page result-page result-workspace-page">
-      <section className="scholarly-workspace result-studio-workspace">
+      <section className="scholarly-workspace result-studio-workspace" data-side-tab={workspaceSideTab}>
+        <div className="workspace-side-tabs" role="tablist" aria-label={`${t("source.title")} / ${t("result.refineTitle")}`}>
+          <button
+            type="button"
+            className={`workspace-side-tab ${workspaceSideTab === "sources" ? "workspace-side-tab-active" : ""}`}
+            aria-selected={workspaceSideTab === "sources"}
+            role="tab"
+            onClick={() => setWorkspaceSideTab("sources")}
+          >
+            <Database size={16} />
+            <span>{t("source.title")}</span>
+          </button>
+          <button
+            type="button"
+            className={`workspace-side-tab ${workspaceSideTab === "config" ? "workspace-side-tab-active" : ""}`}
+            aria-selected={workspaceSideTab === "config"}
+            role="tab"
+            onClick={() => setWorkspaceSideTab("config")}
+          >
+            <Wand2 size={16} />
+            <span>{t("result.refineTitle")}</span>
+          </button>
+        </div>
         <aside className="sources-panel result-sources-panel">
           <div className="workspace-panel-header">
             <div className="workspace-panel-title">

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -30,6 +30,7 @@ import { Layout } from "../components/layout/Layout";
 import { useLocale } from "../i18n";
 import { useGeneration } from "../hooks/useGeneration";
 import { useTemplateImport } from "../hooks/useTemplateImport";
+import { translateTemplateImportMessage } from "../lib/i18nStatus";
 import {
   deleteTemplate,
   fetchTemplateAgentClaudeCodeStatus,
@@ -212,6 +213,7 @@ export function TemplatesPage() {
   const [preview, setPreview] = useState<TemplatePreview | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [focusedPageType, setFocusedPageType] = useState<TemplatePageType>("cover");
+  const [workspaceSideTab, setWorkspaceSideTab] = useState<"sources" | "config">("sources");
 
   // ── Import state ──────────────────────────────────────────────────────
   const [modelConfig] = useState<TemplateImportModelConfig | undefined>(readModelConfig);
@@ -829,7 +831,29 @@ export function TemplatesPage() {
 
   return (
     <Layout showSidebar={false} contentClassName="studio-page templates-workspace-page">
-      <section className="templates-workspace ti-surface">
+      <section className="templates-workspace ti-surface" data-side-tab={workspaceSideTab}>
+        <div className="workspace-side-tabs templates-side-tabs" role="tablist" aria-label={`${t("templates.libraryHeader")} / ${t("templates.collab.title")}`}>
+          <button
+            type="button"
+            className={`workspace-side-tab ${workspaceSideTab === "sources" ? "workspace-side-tab-active" : ""}`}
+            aria-selected={workspaceSideTab === "sources"}
+            role="tab"
+            onClick={() => setWorkspaceSideTab("sources")}
+          >
+            <Library size={16} />
+            <span>{t("templates.libraryHeader")}</span>
+          </button>
+          <button
+            type="button"
+            className={`workspace-side-tab ${workspaceSideTab === "config" ? "workspace-side-tab-active" : ""}`}
+            aria-selected={workspaceSideTab === "config"}
+            role="tab"
+            onClick={() => setWorkspaceSideTab("config")}
+          >
+            <Sparkles size={16} />
+            <span>{t("templates.collab.title")}</span>
+          </button>
+        </div>
         {/* ───────── LEFT COLUMN: Library + upload ───────── */}
         <aside
           className="sources-panel flex flex-col gap-3 overflow-hidden"
@@ -1036,7 +1060,7 @@ export function TemplatesPage() {
                 <div>
                   {collabMode === "agent" ? (
                     <AgentImportingView
-                      message={status?.message || t("template.uploading")}
+                      message={translateTemplateImportMessage(status?.message, locale) || t("template.uploading")}
                       onCancel={handleCancelImport}
                     />
                   ) : (

--- a/frontend/src/pptist/views/Editor/CanvasTool/index.vue
+++ b/frontend/src/pptist/views/Editor/CanvasTool/index.vue
@@ -428,6 +428,33 @@ const openImageLibPanel = () => {
   }
 }
 
+@media screen and (width <= 1500px) {
+  .canvas-tool {
+    gap: 6px;
+    padding: 0 6px;
+  }
+  .left-handler,
+  .right-handler {
+    flex: 0 0 auto;
+  }
+  .add-element-handler {
+    position: static;
+    flex: 1 1 auto;
+    min-width: 0;
+    justify-content: center;
+    overflow: hidden;
+    transform: none;
+
+    .insert-handler-item {
+      margin: 0 1px;
+      padding: 0 7px;
+    }
+  }
+  .handler-item {
+    margin: 0 1px;
+  }
+}
+
 @media screen and (width <= 1600px) {
   .add-element-handler {
     .insert-handler-item {

--- a/frontend/src/pptist/views/Editor/EditorHeader/index.vue
+++ b/frontend/src/pptist/views/Editor/EditorHeader/index.vue
@@ -448,6 +448,56 @@ onBeforeUnmount(() => {
   }
 }
 
+@media screen and (width <= 1500px) {
+  .editor-header {
+    padding-right: 6px;
+  }
+  .left {
+    width: 136px;
+    min-width: 136px;
+  }
+  .title {
+    padding-left: 16px;
+
+    .title-input,
+    .title-text {
+      max-width: 104px;
+    }
+
+    .title-input {
+      width: 104px;
+    }
+  }
+  .header-canvas-tool {
+    min-width: 0;
+    flex: 1 1 0;
+  }
+  .right {
+    gap: 2px;
+  }
+  .menu-item {
+    padding: 0 7px;
+  }
+  .group-menu-item {
+    margin: 0 1px;
+    padding: 0 1px;
+  }
+  .menu-divider {
+    margin: 0 2px;
+  }
+  .paper-save .save-text,
+  .toolbar-toggle .tool-text,
+  .github-link {
+    display: none;
+  }
+  .paper-export-menu .result-export-main {
+    padding: 0 10px;
+  }
+  .paper-export-menu .result-export-caret {
+    width: 30px;
+  }
+}
+
 @media screen and (width <= 1200px) {
   .paper-export-menu .result-export-main span,
   .toolbar-toggle .tool-text,

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -721,7 +721,7 @@ body::before {
     "sources monitor config";
   gap: 12px;
   height: calc(100vh - 64px);
-  min-height: 720px;
+  min-height: min(720px, calc(100vh - 64px));
   padding: 12px 8px 10px;
   overflow: hidden;
 }
@@ -778,6 +778,46 @@ body::before {
   min-width: 0;
   flex-direction: column;
   overflow: hidden;
+}
+
+.workspace-side-tabs {
+  grid-area: sideTabs;
+  display: none;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.workspace-side-tab {
+  display: inline-flex;
+  min-width: 0;
+  height: 32px;
+  flex: 1 1 0;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 0;
+  border-radius: 6px;
+  color: var(--muted);
+  background: transparent;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.workspace-side-tab span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-side-tab-active {
+  color: var(--primary);
+  background: rgba(37, 99, 235, 0.1);
 }
 
 .workspace-panel-header {
@@ -6299,11 +6339,11 @@ body::before {
 
 @media (max-width: 1320px) {
   .scholarly-workspace {
-    grid-template-columns: 280px minmax(0, 1fr);
-    grid-template-rows: auto auto auto;
+    grid-template-columns: minmax(236px, 280px) minmax(0, 1fr);
+    grid-template-rows: 42px minmax(0, 1fr) minmax(116px, 148px);
     grid-template-areas:
-      "sources slides"
-      "config slides"
+      "sideTabs slides"
+      "sidePanel slides"
       "monitor monitor";
   }
 
@@ -7333,6 +7373,295 @@ body::before {
   color: #fff;
   background: rgba(15, 23, 42, 0.55);
   cursor: pointer;
+}
+
+@media (min-width: 1321px) and (max-width: 1500px) {
+  .scholarly-workspace {
+    grid-template-columns: minmax(230px, 260px) minmax(0, 1fr);
+    grid-template-rows: 42px minmax(0, 1fr) minmax(116px, 15vh);
+    grid-template-areas:
+      "sideTabs slides"
+      "sidePanel slides"
+      "monitor monitor";
+    gap: 10px;
+    padding: 10px 8px 8px;
+  }
+
+  .configuration-panel {
+    max-height: none;
+  }
+
+  .configuration-scroll {
+    overflow: auto;
+  }
+
+  .sources-content,
+  .configuration-scroll {
+    gap: 10px;
+    padding: 10px;
+  }
+
+  .sources-panel .upload-zone {
+    min-height: 132px;
+  }
+
+  .slide-workspace-header,
+  .agent-monitor-header {
+    min-height: 40px;
+    padding-right: 12px;
+    padding-left: 12px;
+  }
+
+  .agent-monitor-body,
+  .result-monitor-body {
+    grid-template-columns: 40px minmax(0, 1fr) minmax(180px, 0.8fr) minmax(150px, 0.65fr);
+    gap: 14px;
+    min-height: 86px;
+    padding: 10px 12px;
+  }
+
+  .agent-avatar {
+    width: 38px;
+    height: 38px;
+  }
+
+  .agent-avatar svg {
+    width: 22px;
+    height: 22px;
+  }
+
+  .monitor-event:last-child {
+    display: none;
+  }
+
+  .monitor-progress-block {
+    padding: 0 14px;
+  }
+
+  .recent-task-list {
+    max-height: min(280px, 34vh);
+  }
+
+  .paper-pptist-app .layout-content-left {
+    width: 132px;
+  }
+
+  .paper-pptist-app .layout-content-right {
+    width: 220px;
+  }
+
+  .paper-pptist-app .layout-content-center {
+    width: calc(100% - 132px - 220px);
+  }
+
+  .paper-pptist-app .layout-content-center-expanded {
+    width: calc(100% - 132px);
+  }
+
+  .generate-pptist-empty-shell {
+    grid-template-columns: 148px minmax(0, 1fr);
+  }
+
+  .generate-pptist-disabled-title {
+    width: 148px;
+    min-width: 148px;
+    padding-left: 16px;
+  }
+
+  .generate-pptist-empty-body {
+    grid-template-rows: minmax(0, 1fr) 68px;
+    gap: 10px;
+    padding: 12px 14px 14px;
+  }
+
+  .generate-pptist-empty-canvas {
+    padding: 12px;
+  }
+
+  .generate-pptist-live-slide {
+    width: min(100%, calc((100dvh - 292px) * 16 / 9));
+  }
+
+  .generate-pptist-disabled-actions .generate-pptist-disabled-button:not(.generate-pptist-disabled-primary),
+  .generate-pptist-disabled-actions .generate-pptist-disabled-github {
+    display: none;
+  }
+}
+
+@media (max-width: 1320px) {
+  .result-studio-workspace {
+    grid-template-rows: 42px minmax(0, 1fr) minmax(116px, 148px);
+  }
+}
+
+@media (max-width: 1500px) {
+  .scholarly-workspace > .workspace-side-tabs {
+    display: flex;
+  }
+
+  .scholarly-workspace > .sources-panel,
+  .scholarly-workspace > .configuration-panel {
+    grid-area: sidePanel;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .scholarly-workspace[data-side-tab="sources"] > .sources-panel,
+  .scholarly-workspace[data-side-tab="config"] > .configuration-panel {
+    display: flex;
+  }
+
+  .scholarly-workspace[data-side-tab="sources"] > .configuration-panel,
+  .scholarly-workspace[data-side-tab="config"] > .sources-panel {
+    display: none;
+  }
+}
+
+@media (max-width: 1180px) {
+  .generate-pptist-empty-shell {
+    grid-template-columns: 120px minmax(0, 1fr);
+  }
+
+  .generate-pptist-disabled-title {
+    width: 120px;
+    min-width: 120px;
+    padding-right: 10px;
+    padding-left: 12px;
+  }
+
+  .generate-pptist-disabled-tool {
+    min-width: 0;
+  }
+
+  .generate-pptist-disabled-actions {
+    padding: 0 6px;
+  }
+
+  .generate-pptist-disabled-button {
+    margin: 0;
+  }
+
+  .generate-pptist-disabled-actions .generate-pptist-disabled-button:not(.generate-pptist-disabled-primary),
+  .generate-pptist-disabled-actions .generate-pptist-disabled-github {
+    display: none;
+  }
+
+  .paper-pptist-app .layout-content-left {
+    width: 112px;
+  }
+
+  .paper-pptist-app .layout-content-right {
+    display: none;
+  }
+
+  .paper-pptist-app .layout-content-center,
+  .paper-pptist-app .layout-content-center-expanded {
+    width: calc(100% - 112px);
+  }
+
+  .paper-pptist-app .editor-header .header-canvas-tool {
+    display: none;
+  }
+}
+
+@media (min-width: 1501px) and (max-height: 820px) {
+  .scholarly-workspace {
+    grid-template-rows: minmax(0, 1fr) minmax(96px, 13vh);
+  }
+
+  .sources-panel .upload-zone {
+    min-height: 112px;
+  }
+
+  .recent-task-row-shell,
+  .recent-task-row {
+    min-height: 44px;
+  }
+
+  .agent-monitor-body,
+  .result-monitor-body {
+    min-height: 74px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
+  .generate-pptist-empty-body {
+    grid-template-rows: minmax(0, 1fr) 58px;
+  }
+
+  .generate-pptist-empty-notes {
+    min-height: 48px;
+  }
+}
+
+@media (min-width: 1321px) and (max-width: 1500px) and (max-height: 820px) {
+  .scholarly-workspace {
+    grid-template-rows: 42px minmax(0, 1fr) minmax(96px, 13vh);
+  }
+
+  .sources-panel .upload-zone {
+    min-height: 112px;
+  }
+
+  .recent-task-row-shell,
+  .recent-task-row {
+    min-height: 44px;
+  }
+
+  .agent-monitor-body,
+  .result-monitor-body {
+    min-height: 74px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
+  .generate-pptist-empty-body {
+    grid-template-rows: minmax(0, 1fr) 58px;
+  }
+
+  .generate-pptist-empty-notes {
+    min-height: 48px;
+  }
+}
+
+@media (max-width: 920px) {
+  .scholarly-workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: 42px minmax(360px, auto) minmax(360px, auto) minmax(116px, auto);
+    grid-template-areas:
+      "sideTabs"
+      "sidePanel"
+      "slides"
+      "monitor";
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+  }
+
+  .slide-workspace-panel,
+  .configuration-panel,
+  .agent-monitor-panel {
+    min-height: 360px;
+  }
+
+  .generate-pptist-empty-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: 42px auto minmax(360px, 62vh);
+  }
+
+  .generate-pptist-empty-rail {
+    flex-direction: row;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .generate-pptist-empty-thumb {
+    min-width: 116px;
+  }
+
+  .generate-pptist-empty-body {
+    min-height: 360px;
+  }
 }
 
 .delete-confirm-tooltip {

--- a/frontend/src/styles/template-import-tokens.css
+++ b/frontend/src/styles/template-import-tokens.css
@@ -1982,7 +1982,7 @@
   grid-template-areas: "sources slides config";
   gap: 14px;
   height: calc(100vh - 64px);
-  min-height: 720px;
+  min-height: min(720px, calc(100vh - 64px));
   padding: 14px;
   overflow: hidden;
 }
@@ -2987,4 +2987,159 @@
   color: var(--ti-text);
   font-size: 12px;
   cursor: pointer;
+}
+
+@media (max-width: 1500px) {
+  .templates-workspace {
+    grid-template-columns: minmax(230px, 260px) minmax(0, 1fr);
+    grid-template-rows: 42px minmax(0, 1fr);
+    grid-template-areas:
+      "sideTabs slides"
+      "sidePanel slides";
+    gap: 10px;
+    padding: 10px;
+  }
+
+  .templates-workspace > .workspace-side-tabs {
+    display: flex;
+  }
+
+  .templates-workspace > .sources-panel,
+  .templates-workspace > .templates-config-panel {
+    grid-area: sidePanel !important;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .templates-workspace[data-side-tab="sources"] > .sources-panel,
+  .templates-workspace[data-side-tab="config"] > .templates-config-panel {
+    display: flex;
+  }
+
+  .templates-workspace[data-side-tab="sources"] > .templates-config-panel,
+  .templates-workspace[data-side-tab="config"] > .sources-panel {
+    display: none;
+  }
+
+  .templates-slide-stage-grid {
+    grid-template-columns: clamp(150px, 12vw, 210px) minmax(0, 1fr);
+  }
+
+  .templates-vertical-rail {
+    padding: 10px 8px;
+    gap: 7px;
+  }
+
+  .templates-bottom-rail {
+    grid-template-columns: repeat(5, minmax(98px, 1fr));
+    min-height: clamp(88px, 12vh, 118px);
+    max-height: clamp(104px, 14vh, 132px);
+    margin: 6px 10px 8px;
+    padding: 8px;
+  }
+
+  .templates-bottom-rail .templates-bottom-label {
+    font-size: 10px;
+  }
+
+  .templates-big-preview {
+    padding: 12px;
+  }
+
+  .templates-export-menu .templates-confirm-hint {
+    max-width: 150px;
+  }
+
+  .templates-config-panel > .workspace-panel-header,
+  .templates-config-panel > .templates-config-header {
+    padding: 10px 12px;
+  }
+
+  .ti-review-bottom-tools {
+    grid-template-columns: minmax(200px, 0.5fr) minmax(0, 1fr);
+  }
+}
+
+@media (max-height: 820px) {
+  .templates-workspace {
+    min-height: min(640px, calc(100vh - 64px));
+  }
+
+  .templates-bottom-rail {
+    min-height: 86px;
+    max-height: 108px;
+    margin-top: 5px;
+    margin-bottom: 6px;
+  }
+
+  .templates-bottom-rail .templates-bottom-tile {
+    gap: 3px;
+    padding: 4px;
+  }
+
+  .templates-stage-importing {
+    padding: 14px;
+  }
+
+  .ti-review-bottom-tools {
+    max-height: 118px;
+    overflow: auto;
+  }
+}
+
+@media (max-width: 1320px) {
+  .templates-workspace {
+    grid-template-columns: 236px minmax(0, 1fr);
+    grid-template-rows: 42px minmax(0, 1fr);
+  }
+
+  .templates-config-scroll {
+    overflow: auto;
+  }
+}
+
+@media (max-width: 980px) {
+  .templates-workspace {
+    grid-template-columns: 1fr;
+    grid-template-rows: 42px minmax(320px, auto) minmax(560px, auto);
+    grid-template-areas:
+      "sideTabs"
+      "sidePanel"
+      "slides";
+    overflow: visible;
+  }
+
+  .templates-slide-stage-grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+    min-height: 560px;
+  }
+
+  .templates-slide-stage-grid > .templates-vertical-rail {
+    grid-column: 1;
+    grid-row: 1;
+    flex-direction: row;
+    border-right: 0;
+    border-bottom: 1px solid var(--ti-line);
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .templates-slide-stage-grid > .templates-right-column,
+  .templates-slide-stage-grid:has(.templates-slide-toolbar) > .templates-right-column {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .templates-slide-stage-grid:has(.templates-slide-toolbar) > .templates-vertical-rail {
+    grid-row: 1;
+  }
+
+  .templates-vertical-rail .templates-rail-tile {
+    min-width: 132px;
+  }
+
+  .templates-bottom-rail {
+    grid-template-columns: repeat(5, minmax(118px, 1fr));
+  }
 }

--- a/tests/test_latex_parser.py
+++ b/tests/test_latex_parser.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+from backend.parser.latex_parser import LaTeXParser
+
+
+def test_basic_latex_fallback_preserves_chapter_headings_and_body() -> None:
+    parser = LaTeXParser()
+    content = r"""
+\documentclass{xduugthesis}
+\begin{document}
+\chapter{绪论}
+这里是第一章正文，包含控制系统背景。
+\section{研究问题}
+这里是研究问题正文。
+\subsection{贡献}
+这里是贡献正文。
+\bibliography{ref}
+\end{document}
+"""
+
+    markdown = parser._basic_latex_to_markdown(content)
+    sections = parser._parse_sections(markdown, [])
+
+    assert [section.title for section in sections] == ["绪论", "研究问题", "贡献"]
+    assert sections[0].content == "这里是第一章正文，包含控制系统背景。"
+    assert sections[1].content == "这里是研究问题正文。"
+
+
+def test_resolve_includes_uses_current_file_dir_and_avoids_recursive_bootstrap(
+    tmp_path: Path,
+) -> None:
+    parser = LaTeXParser()
+    main = tmp_path / "main.tex"
+    chapters = tmp_path / "chapters"
+    chapters.mkdir()
+    intro = chapters / "intro.tex"
+
+    main.write_text(
+        r"""
+\documentclass{xduugthesis}
+\begin{document}
+\include{chapters/intro}
+\end{document}
+""",
+        encoding="utf-8",
+    )
+    intro.write_text(
+        r"""
+\input{../main.tex}
+\chapter{绪论}
+章节正文应该只出现一次。
+""",
+        encoding="utf-8",
+    )
+
+    resolved = parser._resolve_includes(main, tmp_path)
+
+    assert resolved.count("章节正文应该只出现一次。") == 1
+    assert r"\input{../main.tex}" not in resolved
+
+
+def test_extract_title_from_xdusetup_info_block() -> None:
+    parser = LaTeXParser()
+    content = r"""
+\documentclass{xduugthesis}
+\xdusetup{
+  info = {
+    title = {面向复杂系统的动力学控制研究},
+    author = {测试作者}
+  }
+}
+\begin{document}
+\end{document}
+"""
+
+    assert parser._extract_title(content) == "面向复杂系统的动力学控制研究"


### PR DESCRIPTION
## Summary
- Add responsive medium-width studio layouts that switch sources/config into side tabs while preserving the normal three-column desktop layout.
- Compact the real PPTist editor header/canvas toolbar and keep PPT previews at a 16:9 ratio across smaller browser widths.
- Fix LaTeX fallback parsing for chapter headings, include recursion, and `\xdusetup` titles for GitHub issue #38.
- Localize missing generation/template progress messages and remove the parallel-generation mode text from the config row.

## Validation
- `npm run build`
- `uv run --with pytest python -m pytest -q tests/test_latex_parser.py`
- Browser layout probes for 1440/1280 widths verified no horizontal overflow and 16:9 PPT preview ratio.

## Notes
- Left existing unstaged local changes alone: `frontend/components.d.ts` and `.tmp_scene_smoke/`.
