### PR TITLE
[codex] Stabilize provider generation runtime

### DIFF
--- a/assets/agent_skills/paper-ppt-generate/scripts/extract_paper_assets.py
+++ b/assets/agent_skills/paper-ppt-generate/scripts/extract_paper_assets.py
@@ -27,6 +27,7 @@ UNSUPPORTED_EXTENSIONS = {".eps", ".ps"}
 MIN_IMAGE_SIDE = 80
 PDF_REGION_DPI = 200
 PDF_IMAGE_DPI = 160
+PDF_CAPTION_MAX_GAP = 360
 
 CAPTION_RE = re.compile(
     r"^\s*((?:fig(?:ure)?|table)\s*\.?\s*\d+[a-z]?|[图表]\s*\d+[a-z]?)\b"
@@ -117,6 +118,10 @@ def extract_pdf(source_path: Path, out_dir: Path, images_dir: Path) -> dict[str,
         import fitz  # type: ignore[import-not-found]
     except Exception as exc:  # pragma: no cover - environment issue
         raise RuntimeError("PyMuPDF is required for PDF asset extraction") from exc
+    try:
+        import pymupdf.layout  # noqa: F401 - enables structured table detection when installed
+    except Exception:
+        pass
 
     doc = fitz.open(str(source_path))
     if doc.needs_pass:
@@ -180,12 +185,51 @@ def extract_pdf(source_path: Path, out_dir: Path, images_dir: Path) -> dict[str,
                 )
             )
 
+        for table_rect, table_caption in _pdf_table_regions(page, captions):
+            if _caption_key(table_caption) in {
+                _caption_key(fig.caption) for fig in figures if fig.page_number == page_no
+            }:
+                continue
+            try:
+                mat = fitz.Matrix(PDF_REGION_DPI / 72, PDF_REGION_DPI / 72)
+                pix = page.get_pixmap(matrix=mat, clip=table_rect, alpha=False)
+                if pix.width < MIN_IMAGE_SIDE or pix.height < MIN_IMAGE_SIDE:
+                    continue
+                img_bytes = pix.tobytes("png")
+            except Exception:
+                continue
+            digest = hashlib.md5(img_bytes).hexdigest()[:12]
+            if digest in seen_hashes:
+                continue
+            seen_hashes.add(digest)
+            name = f"pdf_fig_{len(figures) + 1:03d}_p{page_no}_{digest}.png"
+            target = images_dir / name
+            target.write_bytes(img_bytes)
+            figures.append(
+                FigureRecord(
+                    id=target.stem,
+                    href=f"../source_assets/images/{target.name}",
+                    path=_posix(target),
+                    caption=table_caption,
+                    source="pdf",
+                    page_number=page_no,
+                    bbox=_rect_list(table_rect),
+                    extraction_method="table_region",
+                    natural_width=int(pix.width),
+                    natural_height=int(pix.height),
+                    aspect_ratio=_ratio(int(pix.width), int(pix.height)),
+                    context_before=page_context[0],
+                    context_after=page_context[1],
+                    section_hint=section_hint,
+                )
+            )
+
         used_caption_keys = {_caption_key(fig.caption) for fig in figures if fig.page_number == page_no}
         for cap in captions:
             caption = cap["text"]
             if _caption_key(caption) in used_caption_keys:
                 continue
-            clip = _caption_region_clip(page_rect, cap["rect"], text_blocks)
+            clip = _caption_region_clip(page_rect, cap["rect"], text_blocks, captions)
             if clip is None:
                 continue
             try:
@@ -584,8 +628,18 @@ def _pdf_caption_blocks(text_blocks: list[dict[str, Any]]) -> list[dict[str, Any
     for block in text_blocks:
         text = block["text"].strip()
         if CAPTION_RE.search(text):
-            captions.append({"text": text, "rect": fitz.Rect(block["rect"])})
+            captions.append({"text": _normalize_pdf_caption(text), "rect": fitz.Rect(block["rect"])})
     return captions
+
+
+def _normalize_pdf_caption(text: str) -> str:
+    value = re.sub(r"\s+", " ", (text or "").strip())
+
+    def split_index_year(match: re.Match[str]) -> str:
+        digits = match.group(2)
+        return f"{match.group(1)}{digits[:-4]} {digits[-4:]}"
+
+    return re.sub(r"^([图表]\s*)([0-9０-９]{5,})(?=\s)", split_index_year, value)
 
 
 def _pdf_meaningful_bbox(page_rect: Any, bbox: Any, image_info: dict[str, Any]) -> bool:
@@ -610,12 +664,86 @@ def _nearest_caption_text(bbox: Any, captions: list[dict[str, Any]]) -> str:
     return best
 
 
-def _caption_region_clip(page_rect: Any, caption_rect: Any, text_blocks: list[dict[str, Any]]) -> Any | None:
+def _pdf_table_regions(page: Any, captions: list[dict[str, Any]]) -> list[tuple[Any, str]]:
+    try:
+        import fitz  # type: ignore[import-not-found]
+    except Exception:
+        return []
+    if not hasattr(page, "find_tables"):
+        return []
+    try:
+        tables = page.find_tables().tables
+    except Exception:
+        return []
+    results: list[tuple[Any, str]] = []
+    for table in tables:
+        try:
+            raw_rect = fitz.Rect(table.bbox)
+        except Exception:
+            continue
+        if raw_rect.width < MIN_IMAGE_SIDE or raw_rect.height < MIN_IMAGE_SIDE:
+            continue
+        clip = fitz.Rect(
+            max(page.rect.x0, raw_rect.x0 - 6),
+            max(page.rect.y0, raw_rect.y0 - 6),
+            min(page.rect.x1, raw_rect.x1 + 6),
+            min(page.rect.y1, raw_rect.y1 + 6),
+        )
+        caption = _nearest_caption_text(clip, captions)
+        for cap in captions:
+            cap_rect = fitz.Rect(cap["rect"])
+            if cap["text"] == caption and clip.y0 < cap_rect.y1 < clip.y1:
+                # Some layout backends absorb an above-table caption and
+                # preceding formula into the detected table box. The caption
+                # remains in metadata; keep the rendered asset data-only.
+                clip.y0 = max(clip.y0, cap_rect.y1 + 12)
+                break
+        results.append((clip, caption))
+    return results
+
+
+def _caption_region_clip(
+    page_rect: Any,
+    caption_rect: Any,
+    text_blocks: list[dict[str, Any]],
+    captions: list[dict[str, Any]] | None = None,
+) -> Any | None:
     try:
         import fitz  # type: ignore[import-not-found]
     except Exception:
         return None
-    top = max(page_rect.y0, caption_rect.y0 - min(360, page_rect.height * 0.45))
+    captions = captions or []
+    top = max(page_rect.y0, caption_rect.y0 - min(PDF_CAPTION_MAX_GAP, page_rect.height * 0.45))
+    preceding_captions = [
+        fitz.Rect(cap["rect"])
+        for cap in captions
+        if fitz.Rect(cap["rect"]).y1 < caption_rect.y0 - 2
+    ]
+    if preceding_captions:
+        # The preceding caption is a hard divider on pages containing stacked
+        # figures. It prevents Figure N+1 from swallowing Figure N's panels.
+        top = max(top, max(rect.y1 for rect in preceding_captions) + 10)
+    else:
+        # Tall full-page maps and multi-panel plots can legitimately occupy
+        # more than the fixed caption search window. Expand only on sparse
+        # pages with no intervening prose, retaining the header margin.
+        body_chars = sum(
+            int(block.get("char_count", 0))
+            for block in text_blocks
+            if fitz.Rect(block["rect"]).y0 > page_rect.y0 + page_rect.height * 0.12
+            and fitz.Rect(block["rect"]).y1 < caption_rect.y0
+            and not CAPTION_RE.search(str(block.get("text") or "").strip())
+        )
+        if body_chars < 100:
+            header_bottom = max(
+                (
+                    fitz.Rect(block["rect"]).y1
+                    for block in text_blocks
+                    if fitz.Rect(block["rect"]).y1 <= page_rect.y0 + page_rect.height * 0.14
+                ),
+                default=page_rect.y0 + 20,
+            )
+            top = header_bottom + 8
     for block in text_blocks:
         rect = fitz.Rect(block["rect"])
         if rect.y1 > caption_rect.y0 or rect.y1 < top:

--- a/backend/api/endpoints/generate.py
+++ b/backend/api/endpoints/generate.py
@@ -250,6 +250,7 @@ async def generate_presentation(request: GenerateRequest) -> GenerateResponse:
         language=request.options.language,
         detail_level=request.options.detail_level,
         instruction=request.instruction,
+        worker_backend="huey-sqlite" if generation_backend == "provider" else None,
     )
 
     pipeline_request = GenerationRequest(
@@ -306,35 +307,55 @@ async def generate_presentation(request: GenerateRequest) -> GenerateResponse:
         ),
     )
 
-    scheduler = get_scheduler()
+    if generation_backend == "provider":
+        from backend.queue.tasks import run_generation_job
+        from backend.runtime.job_event_monitor import monitor_job_events, write_generation_request
 
-    async def _runner() -> None:
-        await _run_generation_job(job.id, pipeline_request)
+        request_file = await write_generation_request(job.id, pipeline_request)
+        try:
+            run_generation_job(job.id, str(request_file), pipeline_request.timeout_seconds)
+        except Exception as exc:
+            msg = describe_exception(exc, "Failed to enqueue generation job")
+            session_manager.update_job(job.id, status="error", error=msg, message=msg)
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=msg,
+            ) from exc
+        monitor_task = asyncio.create_task(
+            monitor_job_events(job.id),
+            name=f"job-{job.id}-event-monitor",
+        )
+        session_manager.register_task(job.id, monitor_task)
+    else:
+        scheduler = get_scheduler()
 
-    try:
-        await scheduler.submit(job.id, _runner)
-    except QueueFull as exc:
-        session_manager.update_job(
-            job.id,
-            status="error",
-            error="Server is busy: too many jobs queued.",
-            message="Server is busy: too many jobs queued.",
-        )
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail=str(exc),
-        ) from exc
-    except SchedulerDraining as exc:
-        session_manager.update_job(
-            job.id,
-            status="error",
-            error="Server is shutting down.",
-            message="Server is shutting down.",
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
+        async def _runner() -> None:
+            await _run_generation_job(job.id, pipeline_request)
+
+        try:
+            await scheduler.submit(job.id, _runner)
+        except QueueFull as exc:
+            session_manager.update_job(
+                job.id,
+                status="error",
+                error="Server is busy: too many jobs queued.",
+                message="Server is busy: too many jobs queued.",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=str(exc),
+            ) from exc
+        except SchedulerDraining as exc:
+            session_manager.update_job(
+                job.id,
+                status="error",
+                error="Server is shutting down.",
+                message="Server is shutting down.",
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=str(exc),
+            ) from exc
 
     return GenerateResponse(job_id=job.id, status="queued")
 

--- a/backend/api/endpoints/status.py
+++ b/backend/api/endpoints/status.py
@@ -53,6 +53,11 @@ async def cancel_job(job_id: str) -> CancelJobResponse:
     cancelled = session_manager.cancel_job(job_id)
     if not cancelled:
         session_manager.mark_job_cancelled(job_id)
+        await session_manager.flush_now()
+        return CancelJobResponse(job_id=job_id, status="cancelled")
+    job = session_manager.get_job(job_id)
+    if job is not None and job.status == "cancelled":
+        await session_manager.flush_now()
         return CancelJobResponse(job_id=job_id, status="cancelled")
 
     return CancelJobResponse(job_id=job_id, status="cancelling")

--- a/backend/api/endpoints/status.py
+++ b/backend/api/endpoints/status.py
@@ -12,6 +12,9 @@ router = APIRouter()
 
 @router.get("/status/{job_id}", response_model=JobStatus)
 async def get_job_status(job_id: str) -> JobStatus:
+    from backend.runtime.job_event_monitor import sync_job_events_once
+
+    await sync_job_events_once(job_id)
     job = session_manager.get_job(job_id)
     if job is None:
         raise HTTPException(

--- a/backend/api/websocket.py
+++ b/backend/api/websocket.py
@@ -45,6 +45,12 @@ TERMINAL_STATUSES = {"complete", "error", "cancelled"}
 @router.websocket("/ws/{job_id}")
 async def job_updates(websocket: WebSocket, job_id: str) -> None:
     await websocket.accept()
+    try:
+        from backend.runtime.job_event_monitor import sync_job_events_once
+
+        await sync_job_events_once(job_id)
+    except Exception:
+        pass
 
     # Parse ``?since_seq=N``. Anything malformed → start from 0 (full replay).
     since_seq_raw = websocket.query_params.get("since_seq", "0")

--- a/backend/app.py
+++ b/backend/app.py
@@ -39,6 +39,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             scheduler = get_scheduler()
             await scheduler.start()
             logger.info("scheduler started")
+            from backend.runtime.job_event_monitor import resume_provider_job_monitors
+
+            resume_provider_job_monitors()
         except ImportError:
             scheduler = None
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -113,6 +113,9 @@ class Settings(BaseSettings):
     # ── Job scheduling ───────────────────────────────────────────────────
     # Backlog cap for queued jobs; a 16th queued job returns 429.
     job_queue_capacity: int = 16
+    # Number of Huey consumer slots for provider-backed generation. When 0,
+    # the worker picks a conservative value from local CPU/memory.
+    generation_worker_concurrency: int = 0
 
     # ── External tool timeouts (seconds) ─────────────────────────────────
     pandoc_timeout: int = 60

--- a/backend/dev_launcher.py
+++ b/backend/dev_launcher.py
@@ -55,6 +55,20 @@ def _terminate(proc: subprocess.Popen[str]) -> None:
     if proc.poll() is not None:
         return
     try:
+        import psutil
+
+        parent = psutil.Process(proc.pid)
+        children = parent.children(recursive=True)
+        for child in children:
+            child.terminate()
+        parent.terminate()
+        _, alive = psutil.wait_procs([parent, *children], timeout=5.0)
+        for item in alive:
+            item.kill()
+        return
+    except Exception:
+        pass
+    try:
         proc.terminate()
     except OSError:
         return
@@ -63,6 +77,17 @@ def _terminate(proc: subprocess.Popen[str]) -> None:
 def _kill(proc: subprocess.Popen[str]) -> None:
     if proc.poll() is not None:
         return
+    try:
+        import psutil
+
+        parent = psutil.Process(proc.pid)
+        children = parent.children(recursive=True)
+        for child in children:
+            child.kill()
+        parent.kill()
+        return
+    except Exception:
+        pass
     try:
         proc.kill()
     except OSError:
@@ -135,7 +160,7 @@ def main() -> int:
         print("Paper PPT Agent is starting:", flush=True)
         print("  Backend:  http://127.0.0.1:8000", flush=True)
         print("  Frontend: http://127.0.0.1:5173", flush=True)
-        print("  Worker:   SQLiteHuey local queue", flush=True)
+        print("  Worker:   SQLiteHuey local queue (dynamic concurrency)", flush=True)
         print("Press Ctrl+C to stop all processes.", flush=True)
 
         while not stop:

--- a/backend/dev_launcher.py
+++ b/backend/dev_launcher.py
@@ -1,0 +1,164 @@
+"""One-window development launcher for backend, worker, and frontend."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FRONTEND_DIR = ROOT / "frontend"
+
+
+def _npm_cmd() -> str:
+    return "npm.cmd" if sys.platform.startswith("win") else "npm"
+
+
+def _spawn(name: str, argv: list[str], cwd: Path) -> subprocess.Popen[str]:
+    env = dict(os.environ)
+    env["PYTHONUNBUFFERED"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["FORCE_COLOR"] = "1"
+    env["PY_COLORS"] = "1"
+    env["COLORTERM"] = env.get("COLORTERM", "truecolor")
+    env["TERM"] = env.get("TERM", "xterm-256color")
+    env["npm_config_color"] = "always"
+    proc = subprocess.Popen(
+        argv,
+        cwd=str(cwd),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        bufsize=1,
+        env=env,
+    )
+    thread = threading.Thread(target=_pipe_output, args=(name, proc), daemon=True)
+    thread.start()
+    return proc
+
+
+def _pipe_output(name: str, proc: subprocess.Popen[str]) -> None:
+    if proc.stdout is None:
+        return
+    for line in proc.stdout:
+        print(f"[{name}] {line.rstrip()}", flush=True)
+
+
+def _terminate(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+    except OSError:
+        return
+
+
+def _kill(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        proc.kill()
+    except OSError:
+        pass
+
+
+def main() -> int:
+    processes: list[subprocess.Popen[str]] = []
+    commands = [
+        (
+            "backend",
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "backend.app:app",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8000",
+                "--reload",
+                "--reload-dir",
+                "backend",
+                "--reload-include=*.py",
+                "--use-colors",
+            ],
+            ROOT,
+        ),
+        (
+            "worker",
+            [sys.executable, "-m", "backend.workers.consumer"],
+            ROOT,
+        ),
+        (
+            "frontend",
+            [
+                _npm_cmd(),
+                "run",
+                "dev",
+                "--",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "5173",
+                "--strictPort",
+                "--open",
+            ],
+            FRONTEND_DIR,
+        ),
+    ]
+
+    stop = False
+
+    def _request_stop(_signum: int, _frame: object) -> None:
+        nonlocal stop
+        stop = True
+        for proc in processes:
+            _terminate(proc)
+
+    signal.signal(signal.SIGINT, _request_stop)
+    if hasattr(signal, "SIGTERM"):
+        signal.signal(signal.SIGTERM, _request_stop)
+
+    try:
+        for name, argv, cwd in commands:
+            print(f"==> Starting {name}", flush=True)
+            processes.append(_spawn(name, argv, cwd))
+
+        print("", flush=True)
+        print("Paper PPT Agent is starting:", flush=True)
+        print("  Backend:  http://127.0.0.1:8000", flush=True)
+        print("  Frontend: http://127.0.0.1:5173", flush=True)
+        print("  Worker:   SQLiteHuey local queue", flush=True)
+        print("Press Ctrl+C to stop all processes.", flush=True)
+
+        while not stop:
+            for proc in processes:
+                code = proc.poll()
+                if code is not None:
+                    print(f"process exited with code {code}; stopping dev stack", flush=True)
+                    stop = True
+                    break
+            if stop:
+                break
+            threading.Event().wait(0.5)
+    finally:
+        for proc in processes:
+            _terminate(proc)
+        for proc in processes:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                _kill(proc)
+        print("Dev stack stopped.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/llm/retry.py
+++ b/backend/llm/retry.py
@@ -16,8 +16,8 @@ from typing import TypeVar
 T = TypeVar("T")
 
 
-# Default retry budget: 4 attempts ≈ up to ~15s of backoff + jitter.
-DEFAULT_MAX_ATTEMPTS = 4
+# Default retry budget: 10 attempts ≈ up to ~60s of backoff + jitter.
+DEFAULT_MAX_ATTEMPTS = 10
 DEFAULT_BASE_DELAY = 1.0     # seconds
 DEFAULT_MAX_DELAY = 10.0
 
@@ -31,6 +31,33 @@ def _is_retryable(exc: BaseException) -> bool:
     name = type(exc).__name__.lower()
     # Classic transient signatures.
     if any(tok in name for tok in ("timeout", "connection", "apiconnection")):
+        return True
+    text = str(exc).lower()
+    if any(
+        tok in text
+        for tok in (
+            "socket connection was closed",
+            "connection was closed",
+            "connection closed",
+            "connection reset",
+            "connection aborted",
+            "connection refused",
+            "connection terminated",
+            "broken pipe",
+            "econnreset",
+            "ecconnreset",
+            "read error",
+            "remote protocol error",
+            "server disconnected",
+            "network error",
+            "tls",
+            "ssl",
+            "temporarily unavailable",
+        )
+    ):
+        return True
+    cause = getattr(exc, "__cause__", None) or getattr(exc, "__context__", None)
+    if cause is not None and cause is not exc and _is_retryable(cause):
         return True
     status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
     if isinstance(status, int):

--- a/backend/orchestrator/agent_pipeline.py
+++ b/backend/orchestrator/agent_pipeline.py
@@ -2581,6 +2581,13 @@ def _empty_agent_output_message(project_dir: Path) -> str:
     return f"Agent mode completed without producing SVG slides in svg_output/.{suffix}"
 
 
+def _relative_path(root: Path, path: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
 def _update_agent_usage_totals(totals: _AgentUsageTotals, message: Any) -> AgentProgressEvent | None:
     if totals.runtime == "codex":
         changed = False

--- a/backend/orchestrator/pipeline.py
+++ b/backend/orchestrator/pipeline.py
@@ -26,6 +26,8 @@ from backend.usage.tracker import reset_usage_context, set_usage_context
 
 from .manuscript import count_manuscript_pages
 from . import research_agent, strategist_agent, svg_executor
+from .deck_plan import build_deck_plan
+from .provider_memory import build_provider_memory, build_slide_contexts, save_provider_memory
 from .research_agent import ResearchContext
 from .research_enrichment import enrich_context
 
@@ -223,6 +225,12 @@ async def run_pipeline(
 
         async with heavy_stage_slot():
             paper = await parser.parse(request.file_path, output_dir)
+        provider_memory = build_provider_memory(paper)
+        await aoffload(
+            save_provider_memory,
+            provider_memory,
+            project_dir / "provider_memory",
+        )
 
         parse_info: dict = {}
         if request.source_type == "pdf":
@@ -319,6 +327,7 @@ async def run_pipeline(
                     detail_level=request.detail_level,
                     research_context=research_ctx,
                     enable_deep_research=effective_deep_research,
+                    provider_memory=provider_memory,
                     debug_dir=project_dir / "debug",
                     on_progress=_on_research_progress,
                 )
@@ -411,6 +420,25 @@ async def run_pipeline(
         # Stage 4: SVG executor
         set_usage_context(stage="generation", page=None, attempt=1)
         total_pages = count_manuscript_pages(manuscript)
+        generation_deck_plan = build_deck_plan(
+            manuscript,
+            design_spec,
+            detail_level=request.detail_level,
+        )
+        slide_contexts = build_slide_contexts(
+            manuscript,
+            provider_memory,
+            generation_deck_plan,
+        )
+        if slide_contexts:
+            try:
+                await awrite_text(
+                    project_dir / "provider_memory" / "slide_contexts.json",
+                    json.dumps(slide_contexts, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+            except OSError:
+                pass
         generation_start_data: dict[str, object] = {"total_slides": total_pages}
         if request.generation_mode != "sequential":
             generation_start_data["generation_mode"] = request.generation_mode
@@ -471,6 +499,7 @@ async def run_pipeline(
                 on_critic=_on_critic,
                 on_svg_update=_on_svg_update,
                 figure_inventory=figure_inventory,
+                slide_contexts=slide_contexts,
                 enable_visual_critic=request.enable_visual_critic,
                 max_critic_attempts=request.max_critic_attempts,
                 visual_qa_max_attempts=request.visual_qa_max_attempts,
@@ -493,6 +522,7 @@ async def run_pipeline(
                 on_critic=_on_critic,
                 on_svg_update=_on_svg_update,
                 figure_inventory=figure_inventory,
+                slide_contexts=slide_contexts,
                 enable_visual_critic=request.enable_visual_critic,
                 max_critic_attempts=request.max_critic_attempts,
                 visual_qa_max_attempts=request.visual_qa_max_attempts,

--- a/backend/orchestrator/provider_memory.py
+++ b/backend/orchestrator/provider_memory.py
@@ -1,0 +1,380 @@
+"""Provider-mode working memory for paper-to-deck generation.
+
+The provider pipeline is intentionally stateless at the API boundary, but the
+deck generation task is not. This module builds a small, file-backed working
+memory from the parsed paper so later LLM calls can use scoped evidence instead
+of repeatedly carrying the full paper text.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+from backend.orchestrator.deck_plan import DeckPlan
+from backend.orchestrator.manuscript import extract_page_type, page_title, split_manuscript_pages
+from backend.parser.paper_model import ParsedPaper, PaperFigure, PaperSection
+
+MAX_COMPACT_PAPER_CHARS = 36000
+MAX_SECTION_BRIEF_CHARS = 1400
+MAX_CARD_TEXT_CHARS = 520
+MAX_EVIDENCE_CARDS = 180
+SLIDE_CONTEXT_CARD_COUNT = 7
+
+_WORD_RE = re.compile(r"[A-Za-z][A-Za-z0-9_\-]{2,}|[\u4e00-\u9fff]{2,}")
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[。！？.!?])\s+|\n{2,}")
+_EVIDENCE_RE = re.compile(
+    r"(?i)(\d|%|table|figure|fig\.?|equation|formula|experiment|benchmark|"
+    r"dataset|baseline|sota|accuracy|pass@|rating|flops|cache|latency|"
+    r"ablation|parameter|token|training|inference|图|表|公式|实验|指标|"
+    r"数据集|基线|消融|参数|训练|推理|精度|缓存|延迟)"
+)
+_METHOD_RE = re.compile(
+    r"(?i)(method|architecture|framework|algorithm|module|attention|optimizer|"
+    r"training|pipeline|mechanism|方法|架构|算法|模块|注意力|优化器|机制|流程)"
+)
+
+
+@dataclass(frozen=True)
+class EvidenceCard:
+    id: str
+    section: str
+    kind: str
+    text: str
+    score: float
+    figure_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class FigureMemory:
+    id: str
+    path: str
+    caption: str
+    page_number: int | None
+    natural_width: int
+    natural_height: int
+    quality_score: float
+
+
+@dataclass(frozen=True)
+class SectionMemory:
+    title: str
+    level: int
+    brief: str
+    card_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ProviderMemory:
+    title: str
+    authors: tuple[str, ...]
+    abstract: str
+    compact_markdown: str
+    sections: tuple[SectionMemory, ...]
+    evidence_cards: tuple[EvidenceCard, ...]
+    figures: tuple[FigureMemory, ...]
+
+
+def build_provider_memory(paper: ParsedPaper) -> ProviderMemory:
+    """Build deterministic, compact memory from a parsed paper."""
+    cards: list[EvidenceCard] = []
+    section_memories: list[SectionMemory] = []
+
+    for section_index, section in enumerate(paper.sections, start=1):
+        section_cards = _cards_for_section(section, section_index)
+        cards.extend(section_cards)
+        brief = _section_brief(section, section_cards)
+        section_memories.append(
+            SectionMemory(
+                title=section.title,
+                level=section.level,
+                brief=brief,
+                card_ids=tuple(card.id for card in section_cards),
+            )
+        )
+
+    cards = sorted(cards, key=lambda card: card.score, reverse=True)[:MAX_EVIDENCE_CARDS]
+    card_id_set = {card.id for card in cards}
+    section_memories = [
+        SectionMemory(
+            title=section.title,
+            level=section.level,
+            brief=section.brief,
+            card_ids=tuple(card_id for card_id in section.card_ids if card_id in card_id_set),
+        )
+        for section in section_memories
+    ]
+
+    figures = tuple(_figure_memory(fig) for fig in paper.all_figures() if paper._should_include_figure(fig))
+    compact_markdown = _build_compact_markdown(
+        paper,
+        section_memories,
+        cards,
+        figures,
+    )
+    return ProviderMemory(
+        title=paper.title,
+        authors=tuple(paper.authors),
+        abstract=_trim(paper.abstract, 2200),
+        compact_markdown=compact_markdown,
+        sections=tuple(section_memories),
+        evidence_cards=tuple(cards),
+        figures=figures,
+    )
+
+
+def save_provider_memory(memory: ProviderMemory, target_dir: Path) -> None:
+    """Persist provider working memory for inspection and later reuse."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / "compact_paper.md").write_text(memory.compact_markdown, encoding="utf-8")
+    (target_dir / "evidence_cards.json").write_text(
+        json.dumps([asdict(card) for card in memory.evidence_cards], ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (target_dir / "figures.json").write_text(
+        json.dumps([asdict(fig) for fig in memory.figures], ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    (target_dir / "working_state.md").write_text(_working_state(memory), encoding="utf-8")
+
+
+def build_slide_contexts(
+    manuscript: str,
+    memory: ProviderMemory | None,
+    deck_plan: DeckPlan | None = None,
+) -> dict[int, str]:
+    """Return compact evidence context for each manuscript page."""
+    if memory is None:
+        return {}
+    pages = split_manuscript_pages(manuscript)
+    contexts: dict[int, str] = {}
+    plan_by_page = deck_plan.by_page if deck_plan is not None else {}
+    for page_num, page in enumerate(pages, start=1):
+        slide_plan = plan_by_page.get(page_num)
+        query = "\n".join(
+            part
+            for part in (
+                page_title(page),
+                page,
+                slide_plan.title if slide_plan else "",
+                slide_plan.chapter_title if slide_plan else "",
+            )
+            if part
+        )
+        cards = retrieve_evidence_cards(query, memory, limit=SLIDE_CONTEXT_CARD_COUNT)
+        figure_lines = _slide_figure_hints(page, memory)
+        lines = [
+            "## Provider Slide Working Memory",
+            "",
+            "Use this scoped memory as evidence grounding. Prefer these cards over re-inferring from the full paper.",
+            f"- Slide title: {page_title(page)}",
+            f"- Page type: {extract_page_type(page)}",
+        ]
+        if slide_plan:
+            lines.extend(
+                [
+                    f"- Layout family: {slide_plan.layout_family}",
+                    f"- Density target: {slide_plan.density}",
+                ]
+            )
+        if cards:
+            lines.append("")
+            lines.append("### Relevant Evidence Cards")
+            for card in cards:
+                figure_note = f" figures={', '.join(card.figure_ids)}" if card.figure_ids else ""
+                lines.append(f"- `{card.id}` [{card.kind}] {card.section}:{figure_note} {card.text}")
+        if figure_lines:
+            lines.append("")
+            lines.append("### Figure Hints")
+            lines.extend(figure_lines)
+        contexts[page_num] = "\n".join(lines).strip()
+    return contexts
+
+
+def retrieve_evidence_cards(
+    query: str,
+    memory: ProviderMemory,
+    *,
+    limit: int = SLIDE_CONTEXT_CARD_COUNT,
+) -> list[EvidenceCard]:
+    query_terms = _terms(query)
+    if not query_terms:
+        return list(memory.evidence_cards[:limit])
+    ranked: list[tuple[float, EvidenceCard]] = []
+    for card in memory.evidence_cards:
+        card_terms = _terms(f"{card.section} {card.kind} {card.text}")
+        overlap = len(query_terms.intersection(card_terms))
+        if overlap <= 0:
+            score = card.score * 0.05
+        else:
+            score = overlap * 4.0 + min(card.score, 8.0)
+        ranked.append((score, card))
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    return [card for score, card in ranked[:limit] if score > 0]
+
+
+def _cards_for_section(section: PaperSection, section_index: int) -> list[EvidenceCard]:
+    figure_ids = tuple(fig.fig_id for fig in section.figures if fig.available)
+    candidates: list[EvidenceCard] = []
+    for sentence_index, sentence in enumerate(_candidate_sentences(section.content), start=1):
+        score = _sentence_score(sentence)
+        if score < 1.0 and sentence_index > 4:
+            continue
+        kind = _sentence_kind(sentence)
+        candidates.append(
+            EvidenceCard(
+                id=f"s{section_index:02d}c{sentence_index:03d}",
+                section=section.title,
+                kind=kind,
+                text=_trim(sentence, MAX_CARD_TEXT_CHARS),
+                score=score,
+                figure_ids=figure_ids[:4],
+            )
+        )
+    for table_index, table in enumerate(section.tables, start=1):
+        text = " ".join(part for part in (table.caption, table.markdown) if part).strip()
+        if text:
+            candidates.append(
+                EvidenceCard(
+                    id=f"s{section_index:02d}t{table_index:02d}",
+                    section=section.title,
+                    kind="table",
+                    text=_trim(text, MAX_CARD_TEXT_CHARS),
+                    score=9.0,
+                    figure_ids=(),
+                )
+            )
+    for eq_index, equation in enumerate(section.equations, start=1):
+        if equation.strip():
+            candidates.append(
+                EvidenceCard(
+                    id=f"s{section_index:02d}e{eq_index:02d}",
+                    section=section.title,
+                    kind="equation",
+                    text=_trim(equation.strip(), MAX_CARD_TEXT_CHARS),
+                    score=8.0,
+                    figure_ids=(),
+                )
+            )
+    return sorted(candidates, key=lambda card: card.score, reverse=True)[:10]
+
+
+def _candidate_sentences(text: str) -> list[str]:
+    cleaned = re.sub(r"\s+", " ", text or "").strip()
+    if not cleaned:
+        return []
+    parts = [part.strip() for part in _SENTENCE_SPLIT_RE.split(cleaned) if part.strip()]
+    if len(parts) <= 1:
+        parts = [cleaned[i : i + 420].strip() for i in range(0, len(cleaned), 420)]
+    return [part for part in parts if len(part) >= 35][:60]
+
+
+def _sentence_score(sentence: str) -> float:
+    score = 0.0
+    if _EVIDENCE_RE.search(sentence):
+        score += 4.0
+    if _METHOD_RE.search(sentence):
+        score += 2.0
+    score += min(len(re.findall(r"\d+(?:\.\d+)?%?", sentence)), 6) * 0.7
+    if len(sentence) > 260:
+        score += 0.6
+    return score
+
+
+def _sentence_kind(sentence: str) -> str:
+    if re.search(r"(?i)(result|benchmark|accuracy|pass@|rating|experiment|实验|结果|指标)", sentence):
+        return "result"
+    if _METHOD_RE.search(sentence):
+        return "method"
+    if re.search(r"(?i)(limitation|future|assumption|局限|未来|假设)", sentence):
+        return "limitation"
+    if _EVIDENCE_RE.search(sentence):
+        return "evidence"
+    return "context"
+
+
+def _section_brief(section: PaperSection, cards: Iterable[EvidenceCard]) -> str:
+    card_texts = [card.text for card in cards][:4]
+    if card_texts:
+        return _trim(" ".join(card_texts), MAX_SECTION_BRIEF_CHARS)
+    return _trim(section.content or "", MAX_SECTION_BRIEF_CHARS)
+
+
+def _figure_memory(fig: PaperFigure) -> FigureMemory:
+    caption = (fig.caption or "").replace("\n", " ").strip()
+    return FigureMemory(
+        id=fig.fig_id,
+        path=str(fig.path),
+        caption=_trim(caption, 360),
+        page_number=fig.page_number,
+        natural_width=fig.natural_width,
+        natural_height=fig.natural_height,
+        quality_score=float(fig.quality_score or 0.0),
+    )
+
+
+def _build_compact_markdown(
+    paper: ParsedPaper,
+    sections: list[SectionMemory],
+    cards: list[EvidenceCard],
+    figures: tuple[FigureMemory, ...],
+) -> str:
+    parts = [f"# {paper.title}", ""]
+    if paper.authors:
+        parts.extend([f"**Authors:** {', '.join(paper.authors)}", ""])
+    if paper.abstract:
+        parts.extend(["## Abstract", "", _trim(paper.abstract, 2200), ""])
+    parts.extend(["## Section Working Memory", ""])
+    for section in sections:
+        prefix = "#" * min(max(section.level + 1, 2), 5)
+        parts.extend([f"{prefix} {section.title}", "", section.brief, ""])
+    parts.extend(["## High-Value Evidence Cards", ""])
+    for card in cards[:80]:
+        figure_note = f" figures={', '.join(card.figure_ids)}" if card.figure_ids else ""
+        parts.append(f"- `{card.id}` [{card.kind}] {card.section}:{figure_note} {card.text}")
+    if figures:
+        parts.extend(["", "## Figure Manifest", ""])
+        for fig in figures[:60]:
+            size = f"{fig.natural_width}x{fig.natural_height}" if fig.natural_width and fig.natural_height else "unknown-size"
+            page = f"p{fig.page_number}" if fig.page_number is not None else "page?"
+            parts.append(f"- `{fig.id}` ({page}, {size}, q={fig.quality_score:.2f}) {fig.caption}")
+    compact = "\n".join(parts).strip()
+    if len(compact) > MAX_COMPACT_PAPER_CHARS:
+        compact = compact[:MAX_COMPACT_PAPER_CHARS].rstrip() + "\n\n[Compact paper memory truncated here.]"
+    return compact
+
+
+def _working_state(memory: ProviderMemory) -> str:
+    return (
+        "# Provider Working State\n\n"
+        f"- Paper: {memory.title}\n"
+        f"- Sections indexed: {len(memory.sections)}\n"
+        f"- Evidence cards: {len(memory.evidence_cards)}\n"
+        f"- Figures indexed: {len(memory.figures)}\n\n"
+        "Use `compact_paper.md` for manuscript planning and `evidence_cards.json` "
+        "for slide-scoped retrieval."
+    )
+
+
+def _slide_figure_hints(page_content: str, memory: ProviderMemory) -> list[str]:
+    figure_by_id = {fig.id: fig for fig in memory.figures}
+    hints: list[str] = []
+    for fig_id in re.findall(r"\[\[FIG:([A-Za-z0-9_\-]+)\]\]", page_content):
+        fig = figure_by_id.get(fig_id)
+        if fig:
+            hints.append(f"- `{fig.id}` href={fig.path} caption={fig.caption}")
+    return hints[:5]
+
+
+def _terms(text: str) -> set[str]:
+    return {token.lower() for token in _WORD_RE.findall(text or "") if len(token.strip()) >= 2}
+
+
+def _trim(text: str, limit: int) -> str:
+    value = re.sub(r"\s+", " ", text or "").strip()
+    if len(value) <= limit:
+        return value
+    return value[: max(0, limit - 1)].rstrip() + "…"

--- a/backend/orchestrator/provider_memory.py
+++ b/backend/orchestrator/provider_memory.py
@@ -54,9 +54,13 @@ class FigureMemory:
     path: str
     caption: str
     page_number: int | None
+    bbox: tuple[float, float, float, float] | None
+    extraction_method: str
     natural_width: int
     natural_height: int
+    aspect_ratio: float
     quality_score: float
+    review_flags: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -310,9 +314,13 @@ def _figure_memory(fig: PaperFigure) -> FigureMemory:
         path=str(fig.path),
         caption=_trim(caption, 360),
         page_number=fig.page_number,
+        bbox=fig.bbox,
+        extraction_method=fig.extraction_method,
         natural_width=fig.natural_width,
         natural_height=fig.natural_height,
+        aspect_ratio=fig.aspect_ratio,
         quality_score=float(fig.quality_score or 0.0),
+        review_flags=tuple(fig.review_flags or []),
     )
 
 
@@ -340,7 +348,9 @@ def _build_compact_markdown(
         for fig in figures[:60]:
             size = f"{fig.natural_width}x{fig.natural_height}" if fig.natural_width and fig.natural_height else "unknown-size"
             page = f"p{fig.page_number}" if fig.page_number is not None else "page?"
-            parts.append(f"- `{fig.id}` ({page}, {size}, q={fig.quality_score:.2f}) {fig.caption}")
+            method = f", {fig.extraction_method}" if fig.extraction_method else ""
+            flags = f", flags={','.join(fig.review_flags)}" if fig.review_flags else ""
+            parts.append(f"- `{fig.id}` ({page}, {size}, q={fig.quality_score:.2f}{method}{flags}) {fig.caption}")
     compact = "\n".join(parts).strip()
     if len(compact) > MAX_COMPACT_PAPER_CHARS:
         compact = compact[:MAX_COMPACT_PAPER_CHARS].rstrip() + "\n\n[Compact paper memory truncated here.]"
@@ -365,7 +375,10 @@ def _slide_figure_hints(page_content: str, memory: ProviderMemory) -> list[str]:
     for fig_id in re.findall(r"\[\[FIG:([A-Za-z0-9_\-]+)\]\]", page_content):
         fig = figure_by_id.get(fig_id)
         if fig:
-            hints.append(f"- `{fig.id}` href={fig.path} caption={fig.caption}")
+            hints.append(
+                f"- `{fig.id}` href={fig.path} caption={fig.caption} "
+                f"source={fig.extraction_method or 'unknown'} quality={fig.quality_score:.2f}"
+            )
     return hints[:5]
 
 

--- a/backend/orchestrator/research_agent.py
+++ b/backend/orchestrator/research_agent.py
@@ -36,6 +36,7 @@ from backend.orchestrator.manuscript import (
     strip_page_type_metadata,
     split_manuscript_pages,
 )
+from backend.orchestrator.provider_memory import ProviderMemory
 from backend.parser.paper_model import ParsedPaper
 
 if TYPE_CHECKING:
@@ -140,11 +141,13 @@ async def _run_lightweight_paper_brief(
     detail_level: str = "normal",
     enrichment_block: str = "",
     is_deepseek: bool = False,
+    paper_markdown: str | None = None,
     debug_dir: Path | None = None,
 ) -> str:
     """Extract a compact, evidence-first brief for the non-deep manuscript path."""
+    paper_context = paper_markdown or paper.to_markdown()
     user_parts = [
-        f"## Paper Content\n\n{paper.to_markdown()}",
+        f"## Paper Working Memory\n\n{paper_context}",
         f"\n## Target Language\n\n{language}\n\n{_language_guidance(language)}",
         f"\n## Detail Level\n\n{detail_level}\n\n{DETAIL_GUIDANCE.get(detail_level, DETAIL_GUIDANCE['normal'])}",
     ]
@@ -198,11 +201,13 @@ async def _run_single_pass_analysis(
     enrichment_block: str = "",
     paper_brief: str = "",
     is_deepseek: bool = False,
+    paper_markdown: str | None = None,
     debug_dir: Path | None = None,
 ) -> str:
     """Generate a slide manuscript for the non-deep mode."""
+    paper_context = paper_markdown or paper.to_markdown()
     user_parts = [
-        f"## Paper Content\n\n{paper.to_markdown()}",
+        f"## Paper Working Memory\n\n{paper_context}",
         f"\n## Target Language\n\n{language}\n\n{_language_guidance(language)}",
         f"\n## Target Slides\n\n{_target_slides_guidance(num_pages, detail_level)}",
         f"\n## Detail Level\n\n{detail_level}\n\n{DETAIL_GUIDANCE.get(detail_level, DETAIL_GUIDANCE['normal'])}",
@@ -818,6 +823,7 @@ async def analyze_paper(
     detail_level: str = "normal",
     research_context: ResearchContext | None = None,
     enable_deep_research: bool = False,
+    provider_memory: ProviderMemory | None = None,
     debug_dir: Path | None = None,
     on_progress: Callable[[str, float], None] | None = None,
 ) -> str:
@@ -842,6 +848,7 @@ async def analyze_paper(
     """
     is_deepseek = is_deepseek_provider(llm, model)
     paper_md = paper.to_markdown()
+    compact_paper_md = provider_memory.compact_markdown if provider_memory else paper_md
 
     # External enrichment is injected into Pass 1 specifically — that's where
     # related-work context actually changes the analysis (gap framing,
@@ -864,6 +871,7 @@ async def analyze_paper(
             detail_level=detail_level,
             enrichment_block=enrichment_block,
             is_deepseek=is_deepseek,
+            paper_markdown=compact_paper_md,
             debug_dir=debug_dir,
         )
         logger.info("Research lightweight brief complete (%d chars)", len(paper_brief))
@@ -880,6 +888,7 @@ async def analyze_paper(
             enrichment_block=enrichment_block,
             paper_brief=paper_brief,
             is_deepseek=is_deepseek,
+            paper_markdown=compact_paper_md,
             debug_dir=debug_dir,
         )
         _debug_write_text(debug_dir, "research_final_manuscript.md", manuscript)

--- a/backend/orchestrator/svg_executor.py
+++ b/backend/orchestrator/svg_executor.py
@@ -43,6 +43,8 @@ from backend.usage.tracker import reset_usage_context, set_usage_context
 # `[[FIG:fig_007_p9_page]]` style tokens emitted by the research agent.
 FIG_TOKEN_RE = re.compile(r"\[\[FIG:([A-Za-z0-9_\-]+)\]\]")
 IMAGE_HREF_RE = re.compile(r"<image\b[^>]*\bhref=[\"']([^\"']+)[\"']", re.IGNORECASE)
+IMAGE_TAG_RE = re.compile(r"<image\b(?P<attrs>[^>]*)/?>", re.IGNORECASE | re.DOTALL)
+SVG_ATTR_RE = re.compile(r"([\w:\-]+)\s*=\s*([\"'])(.*?)\2", re.IGNORECASE | re.DOTALL)
 DATA_ICON_RE = re.compile(
     r"<use\b(?=[^>]*\bdata-icon=([\"'])([^\"']+)\1)[^>]*(?:/>|>\s*</use>)",
     re.IGNORECASE | re.DOTALL,
@@ -62,6 +64,11 @@ TEXT_BLOCK_RE = re.compile(r"<text\b(?P<attrs>[^>]*)>(?P<body>.*?)</text>", re.I
 TEXT_X_ATTR_RE = re.compile(r'\bx=(["\'])(?P<value>[^"\']+)\1', re.IGNORECASE)
 TEXT_ANCHOR_ATTR_RE = re.compile(r"\btext-anchor\s*=", re.IGNORECASE)
 NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
+CLIP_RECT_RE = re.compile(
+    r"<clipPath\b[^>]*\bid=([\"'])(?P<id>[^\"']+)\1[^>]*>.*?"
+    r"<rect\b(?P<attrs>[^>]*)/?>.*?</clipPath>",
+    re.IGNORECASE | re.DOTALL,
+)
 
 PROMPT_PATH = Path(__file__).parent / "prompts" / "executor.md"
 
@@ -76,7 +83,12 @@ MAX_PRIOR_PAGES_IN_CONTEXT = 2
 
 # Initial response plus bounded same-page retries when no SVG can be extracted.
 MAX_SVG_EXTRACTION_ATTEMPTS = 3
+SVG_GENERATION_MAX_TOKENS = 8192
+SVG_REPAIR_MAX_TOKENS = 8192
+MAX_DESIGN_SECTION_CHARS = 1800
+MAX_PAGE_DESIGN_CHARS = 2600
 STRUCTURAL_PAGE_TYPES = frozenset({"cover", "chapter", "toc", "ending"})
+FIGURE_SAFETY_CRITIC_ATTEMPTS = 2
 
 CriticMetadata = dict[str, object]
 CriticCallback = Callable[
@@ -233,6 +245,79 @@ def _remove_paper_reference_lines(content: str, disallowed_keys: set[str]) -> st
             continue
         kept.append(line)
     return "\n".join(kept)
+
+
+def _caption_signature(caption: str) -> str:
+    return re.sub(r"\s+", " ", (caption or "").strip().lower())
+
+
+def _figure_slide_score(fig: dict) -> float:
+    """Rank same-caption figure/table candidates for on-slide readability."""
+    quality = float(fig.get("quality_score") or 0.0)
+    width = int(fig.get("natural_width") or 0)
+    height = int(fig.get("natural_height") or 0)
+    ratio = float(fig.get("aspect_ratio") or (width / height if width and height else 0.0))
+    flags = set(fig.get("review_flags") or [])
+    caption = str(fig.get("caption") or "")
+    label = _extract_figure_label(caption)
+
+    score = quality * 10.0
+    if flags:
+        score -= min(len(flags), 4) * 0.8
+    if label and label[0] == "table":
+        # Tables usually read better in a compact, wide crop on a 16:9 slide.
+        score += min(ratio, 5.0) * 0.6
+        if height:
+            score -= min(height, 1200) / 1200.0
+    elif ratio:
+        score += 0.4 if 0.7 <= ratio <= 4.8 else -0.4
+    if width < 240 or height < 120:
+        score -= 2.0
+    return score
+
+
+def _optimize_figure_choices(
+    used_figures: list[dict],
+    figure_inventory: list[dict] | None,
+) -> tuple[list[dict], list[str]]:
+    """Swap selected figures for better same-caption candidates before prompting.
+
+    PDF extraction can yield multiple crops for the same caption. The generation
+    prompt should not force a large, awkward crop when a more slide-friendly
+    sibling exists.
+    """
+    if not used_figures or not figure_inventory:
+        return used_figures, []
+
+    by_caption: dict[str, list[dict]] = {}
+    for fig in figure_inventory:
+        signature = _caption_signature(str(fig.get("caption") or ""))
+        if signature:
+            by_caption.setdefault(signature, []).append(fig)
+
+    optimized: list[dict] = []
+    notes: list[str] = []
+    for fig in used_figures:
+        signature = _caption_signature(str(fig.get("caption") or ""))
+        candidates = [
+            candidate
+            for candidate in by_caption.get(signature, [])
+            if int(candidate.get("page_number") or -1) == int(fig.get("page_number") or -2)
+        ]
+        if len(candidates) < 2:
+            optimized.append(fig)
+            continue
+        best = max(candidates, key=_figure_slide_score)
+        current_key = Path(str(fig.get("path") or "")).stem
+        best_key = Path(str(best.get("path") or "")).stem
+        if best_key and best_key != current_key:
+            notes.append(
+                f"{current_key}: replaced with slide-friendlier same-caption crop {best_key}"
+            )
+            optimized.append(best)
+        else:
+            optimized.append(fig)
+    return optimized, notes
 
 
 def _figures_from_design_spec_for_page(
@@ -501,6 +586,20 @@ def _figure_guidance_block(
         "a different paper-figure href, reuse one from another slide, or invent "
         "a paper-figure path. This does not restrict native SVG visuals."
     )
+    lines.append(
+        "- Generation-time figure safety: place each paper figure as a complete, "
+        "scaled image inside the slide canvas. Do not oversize it and hide parts "
+        "off-canvas. Avoid `clip-path` for paper figures unless the image box and "
+        "the visible clip are nearly the same size. If only one panel of a "
+        "composite source figure is needed, redraw that panel as native SVG "
+        "instead of cropping a huge source image."
+    )
+    lines.append(
+        "- Caption safety: if multiple paper images are shown, caption them "
+        "separately or use a topic caption without combining figure/table "
+        "numbers. If the visible number inside the image may differ from the "
+        "inventory caption, omit the number in the slide caption."
+    )
     return "\n".join(lines)
 
 
@@ -603,6 +702,12 @@ def _figure_layout_guidance(used_figures: list[dict]) -> str:
     ca_bottom = ca_y + ca_h
 
     lines = ["## Image Layout Recommendations"]
+    lines.append(
+        "Hard bounds for paper figures: keep the visible image box within "
+        "x=0..1260 and y=80..640; preferred content area is x=40..1240, "
+        "y=100..620. The image's rendered width/height must be the actual "
+        "visible size, not a larger off-canvas source hidden by clipping."
+    )
 
     # Collect image metadata
     fig_meta: list[dict] = []
@@ -632,7 +737,8 @@ def _figure_layout_guidance(used_figures: list[dict]) -> str:
                 lines.append(
                     f"- {m['stem']}: ratio={r:.2f}, "
                     f"recommended=top-bottom, "
-                    f"image={img_w}x{img_h}, text_area={ca_w}x{txt_h}"
+                    f"image={img_w}x{img_h}, text_area={ca_w}x{txt_h}, "
+                    f"safe_box=(40,{ca_y},{img_w},{img_h})"
                 )
             else:
                 # Left-right: either ratio <= 1.2, or image too tall at full width
@@ -647,13 +753,15 @@ def _figure_layout_guidance(used_figures: list[dict]) -> str:
                     lines.append(
                         f"- {m['stem']}: ratio={r:.2f}, "
                         f"recommended=left-right (image too tall for top-bottom), "
-                        f"image={img_w}x{img_h}, text_area={txt_w}x{ca_h}"
+                        f"image={img_w}x{img_h}, text_area={txt_w}x{ca_h}, "
+                        f"safe_box=({40 + txt_w + 20},{ca_y},{img_w},{img_h})"
                     )
                 else:
                     lines.append(
                         f"- {m['stem']}: ratio={r:.2f}, "
                         f"recommended=left-right, "
-                        f"image={img_w}x{img_h}, text_area={txt_w}x{ca_h}"
+                        f"image={img_w}x{img_h}, text_area={txt_w}x{ca_h}, "
+                        f"safe_box=({40 + txt_w + 20},{ca_y},{img_w},{img_h})"
                     )
         else:
             lines.append(f"- {m['stem']}: unable to read dimensions")
@@ -685,7 +793,9 @@ def _figure_layout_guidance(used_figures: list[dict]) -> str:
                 lines.append(
                     f"- {m['stem']}: ratio={r:.2f}, "
                     f"image={img_w}x{img_h}, "
-                    f"y_start={running_y}, y_end={running_y + img_h}"
+                    f"y_start={running_y}, y_end={running_y + img_h}. "
+                    "Do not crop; if it cannot fit at this size, use a native "
+                    "summary visual instead."
                 )
                 running_y += img_h + 20
             else:
@@ -745,6 +855,162 @@ def _paper_figure_key_from_href(href: str) -> str | None:
     if "/sources/images/" in normalized or stem.startswith("fig_"):
         return stem
     return None
+
+
+def _svg_attrs(attr_text: str) -> dict[str, str]:
+    return {match.group(1): match.group(3) for match in SVG_ATTR_RE.finditer(attr_text or "")}
+
+
+def _svg_number(value: str | None) -> float | None:
+    if value is None:
+        return None
+    match = NUMBER_RE.search(str(value))
+    if not match:
+        return None
+    try:
+        return float(match.group(0))
+    except ValueError:
+        return None
+
+
+def _clip_rects(svg_content: str) -> dict[str, tuple[float, float, float, float]]:
+    rects: dict[str, tuple[float, float, float, float]] = {}
+    for match in CLIP_RECT_RE.finditer(svg_content):
+        attrs = _svg_attrs(match.group("attrs"))
+        x = _svg_number(attrs.get("x")) or 0.0
+        y = _svg_number(attrs.get("y")) or 0.0
+        width = _svg_number(attrs.get("width"))
+        height = _svg_number(attrs.get("height"))
+        if width is not None and height is not None:
+            rects[match.group("id")] = (x, y, width, height)
+    return rects
+
+
+def _clip_id(value: str | None) -> str | None:
+    if not value:
+        return None
+    match = re.search(r"url\(#([^)]+)\)", value)
+    return match.group(1) if match else None
+
+
+def _intersection_area(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+) -> float:
+    ax, ay, aw, ah = a
+    bx, by, bw, bh = b
+    x_overlap = max(0.0, min(ax + aw, bx + bw) - max(ax, bx))
+    y_overlap = max(0.0, min(ay + ah, by + bh) - max(ay, by))
+    return x_overlap * y_overlap
+
+
+def _validate_paper_figure_geometry(
+    svg_content: str,
+    *,
+    allowed_figures: list[dict],
+) -> CriticReport:
+    allowed_by_key = {
+        Path(str(fig.get("path") or "")).stem: fig
+        for fig in allowed_figures
+        if fig.get("path")
+    }
+    clip_rects = _clip_rects(svg_content)
+    violations: list[Violation] = []
+
+    for tag_match in IMAGE_TAG_RE.finditer(svg_content):
+        attrs = _svg_attrs(tag_match.group("attrs"))
+        href = attrs.get("href") or attrs.get("xlink:href") or ""
+        key = _paper_figure_key_from_href(href)
+        if key is None or key not in allowed_by_key:
+            continue
+
+        x = _svg_number(attrs.get("x"))
+        y = _svg_number(attrs.get("y"))
+        width = _svg_number(attrs.get("width"))
+        height = _svg_number(attrs.get("height"))
+        if None in (x, y, width, height):
+            violations.append(
+                Violation(
+                    rule="paper_figure_missing_geometry",
+                    severity="error",
+                    detail=(
+                        f'Paper figure "{key}" must include numeric x, y, width, '
+                        "and height so layout can be verified."
+                    ),
+                )
+            )
+            continue
+
+        assert x is not None and y is not None and width is not None and height is not None
+        fig = allowed_by_key[key]
+        natural_w = float(fig.get("natural_width") or 0)
+        natural_h = float(fig.get("natural_height") or 0)
+        if natural_w > 0 and natural_h > 0 and height > 0:
+            expected_ratio = natural_w / natural_h
+            actual_ratio = width / height
+            if abs(actual_ratio / expected_ratio - 1.0) > 0.06:
+                violations.append(
+                    Violation(
+                        rule="paper_figure_aspect_ratio_changed",
+                        severity="error",
+                        detail=(
+                            f'Paper figure "{key}" rendered ratio {actual_ratio:.2f} '
+                            f"does not match source ratio {expected_ratio:.2f}. "
+                            "Preserve the source aspect ratio."
+                        ),
+                    )
+                )
+
+        if width <= 0 or height <= 0:
+            violations.append(
+                Violation(
+                    rule="paper_figure_invalid_size",
+                    severity="error",
+                    detail=f'Paper figure "{key}" has non-positive rendered size.',
+                )
+            )
+            continue
+
+        right = x + width
+        bottom = y + height
+        if x < -1 or y < 60 or right > 1260 or bottom > 640 or width > 1220 or height > 540:
+            violations.append(
+                Violation(
+                    rule="paper_figure_out_of_bounds",
+                    severity="error",
+                    detail=(
+                        f'Paper figure "{key}" box is x={x:.0f}, y={y:.0f}, '
+                        f"w={width:.0f}, h={height:.0f}, extending to "
+                        f"x={right:.0f}, y={bottom:.0f}. Keep the full visible "
+                        "paper figure within the slide canvas/content band; do "
+                        "not hide source-image overflow off-canvas."
+                    ),
+                )
+            )
+
+        clip = attrs.get("clip-path")
+        clip_key = _clip_id(clip)
+        if clip_key and clip_key in clip_rects:
+            image_box = (x, y, width, height)
+            clip_box = clip_rects[clip_key]
+            visible = _intersection_area(image_box, clip_box)
+            image_area = width * height
+            visible_fraction = visible / image_area if image_area else 0.0
+            if visible_fraction < 0.72:
+                violations.append(
+                    Violation(
+                        rule="paper_figure_overcropped",
+                        severity="error",
+                        detail=(
+                            f'Paper figure "{key}" is clipped to only '
+                            f"{visible_fraction:.0%} of its rendered image box. "
+                            "Resize the image to the visible frame or redraw the "
+                            "desired subpanel with native SVG."
+                        ),
+                    )
+                )
+
+    return CriticReport(passed=not violations, violations=violations)
 
 
 def _validate_paper_figure_refs(
@@ -874,6 +1140,32 @@ def _validate_icon_refs(
         violations.extend(_pseudo_icon_badge_violations(svg_content))
 
     return CriticReport(passed=not violations, violations=violations)
+
+
+def _generation_static_report(
+    svg_content: str,
+    *,
+    critic_config: CriticConfig,
+    allowed_figures: list[dict],
+    used_paper_figures: dict[str, int],
+    required_icon: str | None,
+    include_general_svg_checks: bool,
+) -> CriticReport:
+    reports = [
+        _validate_paper_figure_refs(
+            svg_content,
+            allowed_figures=allowed_figures,
+            used_paper_figures=used_paper_figures,
+        ),
+        _validate_paper_figure_geometry(
+            svg_content,
+            allowed_figures=allowed_figures,
+        ),
+        _validate_icon_refs(svg_content, required_icon=required_icon),
+    ]
+    if include_general_svg_checks:
+        reports.insert(0, check_svg(svg_content, critic_config))
+    return _merge_reports(*reports)
 
 
 def _pseudo_icon_badge_violations(svg_content: str) -> list[Violation]:
@@ -1069,6 +1361,7 @@ async def generate_svg_pages(
     on_critic: CriticCallback | None = None,
     on_svg_update: SvgUpdateCallback | None = None,
     figure_inventory: list[dict] | None = None,
+    slide_contexts: dict[int, str] | None = None,
     enable_visual_critic: bool = False,
     max_critic_attempts: int = DEFAULT_MAX_CRITIC_ATTEMPTS,
     visual_qa_max_attempts: int = 1,
@@ -1094,6 +1387,7 @@ async def generate_svg_pages(
         detail_level=detail_level,
     )
     deck_plan_block = deck_plan_markdown(deck_plan)
+    compact_design_spec = _parallel_global_design_context(design_spec)
     try:
         (project_dir / "deck_plan.md").write_text(deck_plan_block, encoding="utf-8")
     except OSError:
@@ -1118,7 +1412,7 @@ async def generate_svg_pages(
     conversation: list[LLMMessage] = [
         LLMMessage.system(system_prompt),
         LLMMessage.user(
-            f"## Design Specification\n\n{design_spec}\n\n"
+            f"## Compact Global Design Specification\n\n{compact_design_spec}\n\n"
             f"## Structured Deck Plan (authoritative)\n\n{deck_plan_block}\n\n"
             f"## SVG Technical Standards\n\n{standards}\n\n"
             f"## Fixed Runtime Configuration\n\n"
@@ -1203,6 +1497,17 @@ async def generate_svg_pages(
                     "Design spec image assignment recovered for this slide:\n"
                     f"{fallback_refs}"
                 )
+        used_figures, optimized_figure_notes = _optimize_figure_choices(
+            used_figures,
+            figure_inventory,
+        )
+        rejected_figures.extend(optimized_figure_notes)
+        if optimized_figure_notes and used_figures:
+            rewritten_content += (
+                "\n\nOptimized paper figure assignment for generation "
+                "(use these instead of any earlier figure assignment lines):\n"
+                + "\n".join(_paper_figure_reference_line(fig) for fig in used_figures)
+            )
         figure_guidance = _figure_guidance_block(
             used_figures,
             rejected_figures,
@@ -1242,9 +1547,28 @@ async def generate_svg_pages(
                 )
 
         slide_plan_block = slide_plan_markdown(deck_plan, page_num)
+        page_design_block = _extract_page_design_block(design_spec, page_num)
+        if is_structural_page:
+            page_design_block = _sanitize_structural_page_design_block(
+                page_design_block,
+                page_type,
+            )
+        page_design_section = (
+            f"## Page Design Contract\n\n{page_design_block}\n\n"
+            if page_design_block
+            else ""
+        )
+        slide_memory = (slide_contexts or {}).get(page_num, "").strip()
+        slide_memory_section = (
+            f"\n\n{slide_memory}\n\n"
+            if slide_memory
+            else "\n\n"
+        )
         conversation.append(
             LLMMessage.user(
                 f"## Current Structured Slide Plan\n\n{slide_plan_block}\n\n"
+                f"{slide_memory_section}"
+                f"{page_design_section}"
                 f"## Page {page_num}/{len(pages)}: {page_name}\n\n"
                 f"{rewritten_content}\n\n"
                 f"## Runtime Reminders\n"
@@ -1260,6 +1584,15 @@ async def generate_svg_pages(
                 f"{figure_guidance}\n\n"
                 f"{icon_guidance}\n\n"
                 f"{img_layout}\n\n"
+                f"## Output Complexity Budget\n"
+                f"- Keep the SVG compact and editable; target under {SVG_GENERATION_MAX_TOKENS} output tokens.\n"
+                f"- Prefer grouped primitives, reusable styles, and concise text. Avoid huge decorative path dumps or duplicate off-canvas elements.\n\n"
+                f"## Pre-Generation Boundary Check\n"
+                f"Before writing SVG, mentally plan y-coordinates and image boxes:\n"
+                f"- Content area: y=100 to y=620 (520px). This is the preferred limit.\n"
+                f"- Paper figures must stay fully visible inside x=0..1260 and y=80..640.\n"
+                f"- Do not make an image larger than its visible frame and hide it with clip-path or off-canvas overflow.\n"
+                f"- If the plan does not fit, shrink the figure, use fewer text blocks, or redraw a native summary visual.\n\n"
                 f"Generate the complete SVG code for this page. "
                 f"Output ONLY the SVG code, wrapped in ```svg code block."
                 f"{skeleton_block}"
@@ -1277,7 +1610,10 @@ async def generate_svg_pages(
         snapshot = set_usage_context(stage="generation", page=page_num, attempt=1)
         try:
             response: LLMResponse = await llm.chat(
-                conversation, model, temperature=0.3, max_tokens=16384
+                conversation,
+                model,
+                temperature=0.3,
+                max_tokens=SVG_GENERATION_MAX_TOKENS,
             )
         finally:
             reset_usage_context(snapshot)
@@ -1303,7 +1639,10 @@ async def generate_svg_pages(
             )
             try:
                 response = await llm.chat(
-                    conversation, model, temperature=0.2, max_tokens=16384
+                    conversation,
+                    model,
+                    temperature=0.2,
+                    max_tokens=SVG_GENERATION_MAX_TOKENS,
                 )
             finally:
                 reset_usage_context(snapshot)
@@ -1315,24 +1654,30 @@ async def generate_svg_pages(
             best_svg = svg_content
             visual_attempts = 0
             critic_attempt = 1
+            static_attempt_limit = (
+                max_critic_attempts
+                if max_critic_attempts > 0
+                else FIGURE_SAFETY_CRITIC_ATTEMPTS
+            )
             while True:
                 report: CriticReport | None = None
                 report_metadata: CriticMetadata = {"source": "static"}
                 event_attempt = critic_attempt
 
-                if max_critic_attempts > 0:
-                    report = _merge_reports(
-                        check_svg(svg_content, critic_config),
-                        _validate_paper_figure_refs(
-                            svg_content,
-                            allowed_figures=used_figures,
-                            used_paper_figures=used_paper_figures,
-                        ),
-                        _validate_icon_refs(svg_content, required_icon=required_icon),
+                if static_attempt_limit > 0:
+                    report = _generation_static_report(
+                        svg_content,
+                        critic_config=critic_config,
+                        allowed_figures=used_figures,
+                        used_paper_figures=used_paper_figures,
+                        required_icon=required_icon,
+                        include_general_svg_checks=max_critic_attempts > 0,
                     )
+                    if report.passed and max_critic_attempts <= 0:
+                        report = None
                     report_metadata = {"source": "static"}
                     event_attempt = critic_attempt
-                    if not report.passed and critic_attempt >= max_critic_attempts:
+                    if report is not None and not report.passed and critic_attempt >= static_attempt_limit:
                         archive_rel = _archive_repair_svg(
                             repair_archive_dir,
                             page_num=page_num,
@@ -1429,7 +1774,11 @@ async def generate_svg_pages(
 
                 repair_prompt_text = (
                     report.to_prompt_block()
-                    + "\n\nReturn the complete corrected SVG only, "
+                    + "\n\nWhen fixing paper-figure violations, resize the image "
+                    "to the visible frame, preserve the source aspect ratio, keep "
+                    "the full rendered image inside x=0..1260 and y=80..640, and "
+                    "remove over-cropping clip paths. Do not swap to an unlisted "
+                    "paper figure href.\n\nReturn the complete corrected SVG only, "
                     "wrapped in a ```svg code block."
                 )
                 conversation.append(LLMMessage.user(repair_prompt_text))
@@ -1439,7 +1788,10 @@ async def generate_svg_pages(
                 )
                 try:
                     response = await llm.chat(
-                        conversation, model, temperature=repair_temp, max_tokens=16384
+                        conversation,
+                        model,
+                        temperature=repair_temp,
+                        max_tokens=SVG_REPAIR_MAX_TOKENS,
                     )
                 finally:
                     reset_usage_context(snapshot)
@@ -1519,6 +1871,14 @@ def _extract_design_section(design_spec: str, roman: str) -> str:
     return match.group(0).strip() if match else ""
 
 
+def _compact_prompt_block(text: str, limit: int, *, label: str = "context") -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    head = text[: max(0, limit - 120)].rstrip()
+    return f"{head}\n\n[{label} compacted to {limit} characters for provider working-memory mode.]"
+
+
 def _extract_page_design_block(design_spec: str, page_num: int) -> str:
     pattern = (
         rf"(?ims)^#+\s*(?:slide|page)\s*0*{page_num}\b.*?"
@@ -1527,7 +1887,11 @@ def _extract_page_design_block(design_spec: str, page_num: int) -> str:
         rf"|^#+\s*[IVXLCDM]+\.\s+|\Z)"
     )
     match = re.search(pattern, design_spec)
-    return match.group(0).strip() if match else ""
+    return _compact_prompt_block(
+        match.group(0).strip(),
+        MAX_PAGE_DESIGN_CHARS,
+        label=f"page {page_num} design block",
+    ) if match else ""
 
 
 def _extract_page_section_heading(design_spec: str, page_num: int) -> str:
@@ -1957,7 +2321,11 @@ def _template_skeleton_instruction(page_type: str) -> str:
 
 def _parallel_global_design_context(design_spec: str) -> str:
     sections = [
-        _extract_design_section(design_spec, roman)
+        _compact_prompt_block(
+            _extract_design_section(design_spec, roman),
+            MAX_DESIGN_SECTION_CHARS,
+            label=f"design section {roman}",
+        )
         for roman in ("I", "II", "III", "IV", "V", "VI")
     ]
     compact = "\n\n".join(section for section in sections if section)
@@ -2129,6 +2497,7 @@ def _prepare_parallel_page_inputs(
     claimed_paper_figures: set[str],
     template_vars: dict[str, str] | None = None,
     slide_plan: str = "",
+    slide_context: str = "",
 ) -> dict:
     page_name = _make_page_name(page_num, page_content)
     page_type = _classify_page_type(page_content)
@@ -2165,6 +2534,18 @@ def _prepare_parallel_page_inputs(
                 "Design spec image assignment recovered for this slide:\n"
                 f"{fallback_refs}"
             )
+
+    used_figures, optimized_figure_notes = _optimize_figure_choices(
+        used_figures,
+        figure_inventory,
+    )
+    rejected_figures.extend(optimized_figure_notes)
+    if optimized_figure_notes and used_figures:
+        rewritten_content += (
+            "\n\nOptimized paper figure assignment for generation "
+            "(use these instead of any earlier figure assignment lines):\n"
+            + "\n".join(_paper_figure_reference_line(fig) for fig in used_figures)
+        )
 
     duplicate_keys = _paper_figure_keys(used_figures).intersection(claimed_paper_figures)
     if duplicate_keys:
@@ -2203,6 +2584,7 @@ def _prepare_parallel_page_inputs(
         "page_design_block": page_design_block,
         "template_vars": template_vars or {},
         "slide_plan": slide_plan,
+        "slide_context": slide_context,
     }
 
 
@@ -2239,6 +2621,7 @@ async def _generate_parallel_page(
     page_design_block = str(page_input["page_design_block"] or "")
     template_vars = dict(page_input.get("template_vars") or {})
     slide_plan = str(page_input.get("slide_plan") or "").strip()
+    slide_context = str(page_input.get("slide_context") or "").strip()
     previous_layout_style = str(page_input.get("previous_layout_style") or "").strip()
     is_structural_page = bool(page_input["is_structural_page"])
 
@@ -2289,6 +2672,11 @@ async def _generate_parallel_page(
         if slide_plan
         else ""
     )
+    slide_context_section = (
+        f"\n\n{slide_context}"
+        if slide_context
+        else ""
+    )
     page_design_section = (
         f"\n\n## Page Design Contract\n\n{page_design_block}"
         if page_design_block
@@ -2318,6 +2706,7 @@ async def _generate_parallel_page(
             f"- Use the Typography System from the global design contract as the single source of truth for fonts and size hierarchy."
             f"{extra_block}"
             f"{slide_plan_section}"
+            f"{slide_context_section}"
             f"{page_design_section}\n\n"
             f"{previous_layout_section}\n\n"
             f"## Page {page_num}/{total_pages}: {page_name}\n\n"
@@ -2335,6 +2724,9 @@ async def _generate_parallel_page(
             f"{figure_guidance}\n\n"
             f"{icon_guidance}\n\n"
             f"{img_layout}\n\n"
+            f"## Output Complexity Budget\n"
+            f"- Keep the SVG compact and editable; target under {SVG_GENERATION_MAX_TOKENS} output tokens.\n"
+            f"- Prefer grouped primitives, reusable styles, and concise text. Avoid huge decorative path dumps or duplicate off-canvas elements.\n\n"
             f"## Pre-Generation Boundary Check\n"
             f"Before writing SVG, mentally plan y-coordinates top to bottom:\n"
             f"- Content area: y=100 to y=620 (520px). This is a hard limit.\n"
@@ -2364,7 +2756,7 @@ async def _generate_parallel_page(
             conversation,
             model,
             temperature=0.3,
-            max_tokens=16384,
+            max_tokens=SVG_GENERATION_MAX_TOKENS,
         )
     finally:
         reset_usage_context(snapshot)
@@ -2395,7 +2787,7 @@ async def _generate_parallel_page(
                 conversation,
                 model,
                 temperature=0.2,
-                max_tokens=16384,
+                max_tokens=SVG_GENERATION_MAX_TOKENS,
             )
         finally:
             reset_usage_context(snapshot)
@@ -2415,23 +2807,29 @@ async def _generate_parallel_page(
     critic_attempt = 1
     max_critic_attempts = max(0, int(max_critic_attempts))
     visual_qa_max_attempts = max(0, int(visual_qa_max_attempts or 0))
+    static_attempt_limit = (
+        max_critic_attempts
+        if max_critic_attempts > 0
+        else FIGURE_SAFETY_CRITIC_ATTEMPTS
+    )
 
     while True:
         report: CriticReport | None = None
         report_metadata: CriticMetadata = {"source": "static"}
         event_attempt = critic_attempt
 
-        if max_critic_attempts > 0:
-            report = _merge_reports(
-                check_svg(svg_content, critic_config),
-                _validate_paper_figure_refs(
-                    svg_content,
-                    allowed_figures=used_figures,
-                    used_paper_figures={},
-                ),
-                _validate_icon_refs(svg_content, required_icon=required_icon),
+        if static_attempt_limit > 0:
+            report = _generation_static_report(
+                svg_content,
+                critic_config=critic_config,
+                allowed_figures=used_figures,
+                used_paper_figures={},
+                required_icon=required_icon,
+                include_general_svg_checks=max_critic_attempts > 0,
             )
-            if not report.passed and critic_attempt >= max_critic_attempts:
+            if report.passed and max_critic_attempts <= 0:
+                report = None
+            if report is not None and not report.passed and critic_attempt >= static_attempt_limit:
                 archive_rel = _archive_repair_svg(
                     repair_archive_dir,
                     page_num=page_num,
@@ -2521,7 +2919,11 @@ async def _generate_parallel_page(
         )
         repair_prompt_text = (
             report.to_prompt_block()
-            + "\n\nReturn the complete corrected SVG only, wrapped in a ```svg code block."
+            + "\n\nWhen fixing paper-figure violations, resize the image "
+            "to the visible frame, preserve the source aspect ratio, keep "
+            "the full rendered image inside x=0..1260 and y=80..640, and "
+            "remove over-cropping clip paths. Do not swap to an unlisted "
+            "paper figure href.\n\nReturn the complete corrected SVG only, wrapped in a ```svg code block."
         )
         conversation.append(LLMMessage.user(repair_prompt_text))
         repair_temp = max(0.1, 0.3 - 0.1 * event_attempt)
@@ -2531,7 +2933,7 @@ async def _generate_parallel_page(
                 conversation,
                 model,
                 temperature=repair_temp,
-                max_tokens=16384,
+                max_tokens=SVG_REPAIR_MAX_TOKENS,
             )
         finally:
             reset_usage_context(snapshot)
@@ -2629,6 +3031,7 @@ async def generate_svg_pages_parallel(
     on_critic: CriticCallback | None = None,
     on_svg_update: SvgUpdateCallback | None = None,
     figure_inventory: list[dict] | None = None,
+    slide_contexts: dict[int, str] | None = None,
     enable_visual_critic: bool = False,
     max_critic_attempts: int = DEFAULT_MAX_CRITIC_ATTEMPTS,
     visual_qa_max_attempts: int = 1,
@@ -2693,6 +3096,7 @@ async def generate_svg_pages_parallel(
                 claimed_paper_figures=claimed_paper_figures,
                 template_vars=template_vars.get(page_num),
                 slide_plan=slide_plan_markdown(deck_plan, page_num),
+                slide_context=(slide_contexts or {}).get(page_num, ""),
             )
         )
 
@@ -2844,6 +3248,7 @@ def _build_svg_extraction_retry_prompt(
         "## Regeneration Instructions\n"
         f"- Regenerate page {page_num}/{total_pages} only; do not move to another page.\n"
         "- Preserve the page content below; do not invent a different slide.\n"
+        "- Keep the SVG concise: prefer native text/rect/path groups, avoid excessive decorative paths, and stay well below the token limit.\n"
         "- Return one complete SVG document, wrapped in a ```svg code block.\n"
         "- The SVG must start with `<svg` and end with `</svg>`.\n\n"
         f"## Page Content To Render\n\n{page_content}\n\n"

--- a/backend/parser/pdf_parser.py
+++ b/backend/parser/pdf_parser.py
@@ -79,7 +79,7 @@ LABEL_TEXT_CHARS_THRESHOLD = 80
 # ─────────────────────────────────────────────────────────────────────────────
 
 _CAPTION_RE = re.compile(
-    r"^\s*(fig(?:ure)?\.?\s*\d+|table\s*\d+)\b",
+    r"^\s*(fig(?:ure)?\.?\s*[0-9０-９]+|table\s*[0-9０-９]+|[图表]\s*[0-9０-９]+)",
     re.IGNORECASE,
 )
 
@@ -346,8 +346,19 @@ class PDFParser(PaperParser):
             if m:
                 key = re.sub(r"\s+", "", m.group(0).lower())
                 rect = fitz.Rect(block["bbox"])
-                result[key] = (block_text, rect)
+                result[key] = (self._normalize_caption_text(block_text), rect)
         return result
+
+    @staticmethod
+    def _normalize_caption_text(text: str) -> str:
+        """Restore spacing when PDF extraction joins a figure index to a year."""
+        value = re.sub(r"\s+", " ", (text or "").strip())
+
+        def split_index_year(match: re.Match[str]) -> str:
+            digits = match.group(2)
+            return f"{match.group(1)}{digits[:-4]} {digits[-4:]}"
+
+        return re.sub(r"^([图表]\s*)([0-9０-９]{5,})(?=\s)", split_index_year, value)
 
     def _nearest_caption(
         self,
@@ -358,8 +369,9 @@ class PDFParser(PaperParser):
         best_dist = float("inf")
         best_cap = ""
         for _key, (cap_text, cap_rect) in caption_map.items():
-            # vertical distance between centres
-            dist = abs(cap_rect.y0 - img_rect.y1)
+            # Captions usually sit below figures but above tables. Compare the
+            # nearest vertical edges so both conventions retain their identity.
+            dist = min(abs(cap_rect.y0 - img_rect.y1), abs(img_rect.y0 - cap_rect.y1))
             if dist < best_dist and dist < CAPTION_SEARCH_PX * 2:
                 best_dist = dist
                 best_cap = cap_text
@@ -517,6 +529,13 @@ class PDFParser(PaperParser):
                 )
             if clip is None:
                 continue
+            clip = self._normalize_caption_clip(
+                clip,
+                page_rect,
+                cap_rect,
+                text_blocks,
+                caption_map,
+            )
 
             if self._is_region_already_covered(clip, raster_rects):
                 continue
@@ -885,6 +904,54 @@ class PDFParser(PaperParser):
                 continue
             trimmed.y0 = max(trimmed.y0, rect.y1 + 4)
         return trimmed
+
+    def _normalize_caption_clip(
+        self,
+        clip: fitz.Rect,
+        page_rect: fitz.Rect,
+        caption_rect: fitz.Rect,
+        text_blocks: list[dict],
+        caption_map: dict[str, tuple[str, fitz.Rect]],
+    ) -> fitz.Rect:
+        """Keep stacked crops separate while restoring sparse full-page figures."""
+        normalized = fitz.Rect(clip)
+        preceding_captions = [
+            other_rect
+            for _, other_rect in caption_map.values()
+            if other_rect.y1 < caption_rect.y0 - 2
+        ]
+        if preceding_captions:
+            horizontal_pad = max(20.0, page_rect.width * 0.04)
+            normalized.x0 = page_rect.x0 + horizontal_pad
+            normalized.x1 = page_rect.x1 - horizontal_pad
+            normalized.y0 = max(normalized.y0, max(rect.y1 for rect in preceding_captions) + 10)
+            normalized.y1 = caption_rect.y0 - 4
+            return normalized
+
+        body_chars = sum(
+            block["char_count"]
+            for block in text_blocks
+            if block["rect"].y0 > page_rect.y0 + page_rect.height * 0.12
+            and block["rect"].y1 < caption_rect.y0
+            and not _CAPTION_RE.search(block["text"].strip())
+        )
+        if body_chars >= 100:
+            return normalized
+
+        header_bottom = max(
+            (
+                block["rect"].y1
+                for block in text_blocks
+                if block["rect"].y1 <= page_rect.y0 + page_rect.height * 0.14
+            ),
+            default=page_rect.y0 + 20,
+        )
+        horizontal_pad = max(20.0, page_rect.width * 0.04)
+        normalized.x0 = page_rect.x0 + horizontal_pad
+        normalized.x1 = page_rect.x1 - horizontal_pad
+        normalized.y0 = header_bottom + 8
+        normalized.y1 = caption_rect.y0 - 4
+        return normalized
 
     def _is_region_already_covered(self, region: fitz.Rect, raster_rects: list[fitz.Rect]) -> bool:
         for rect in raster_rects:

--- a/backend/queue/__init__.py
+++ b/backend/queue/__init__.py
@@ -1,0 +1,1 @@
+"""Local task queue integration."""

--- a/backend/queue/broker.py
+++ b/backend/queue/broker.py
@@ -1,0 +1,21 @@
+"""Huey broker configuration.
+
+The default broker is SQLite so source checkouts work on Windows/Linux without
+Docker or Redis. The worker is still a separate process from FastAPI.
+"""
+
+from __future__ import annotations
+
+from huey import SqliteHuey
+
+from backend.config import settings
+
+
+settings.runtime_dir.mkdir(parents=True, exist_ok=True)
+
+huey = SqliteHuey(
+    "paper-ppt-agent",
+    filename=str(settings.runtime_dir / "jobs.sqlite"),
+    results=False,
+    immediate=False,
+)

--- a/backend/queue/tasks.py
+++ b/backend/queue/tasks.py
@@ -1,0 +1,17 @@
+"""Huey tasks for background generation."""
+
+from __future__ import annotations
+
+import logging
+
+from backend.queue.broker import huey
+from backend.workers.subprocess_runner import run_generation_subprocess
+
+
+logger = logging.getLogger(__name__)
+
+
+@huey.task()
+def run_generation_job(job_id: str, request_file: str, timeout: float | None = None) -> int:
+    logger.info("dequeued generation job %s", job_id)
+    return run_generation_subprocess(job_id, request_file, timeout=timeout)

--- a/backend/queue/tasks.py
+++ b/backend/queue/tasks.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
+from backend.config import settings
 from backend.queue.broker import huey
 from backend.workers.subprocess_runner import run_generation_subprocess
 
@@ -11,7 +13,25 @@ from backend.workers.subprocess_runner import run_generation_subprocess
 logger = logging.getLogger(__name__)
 
 
+def _persisted_job_status(job_id: str) -> str | None:
+    """Read current API-owned state, avoiding stale consumer process memory."""
+    try:
+        payload = json.loads(
+            (settings.runtime_dir / "session_state.json").read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError):
+        return None
+    for job in payload.get("jobs", []):
+        if isinstance(job, dict) and str(job.get("id")) == job_id:
+            return str(job.get("status") or "")
+    return None
+
+
 @huey.task()
 def run_generation_job(job_id: str, request_file: str, timeout: float | None = None) -> int:
+    current_status = _persisted_job_status(job_id)
+    if current_status in {"complete", "error", "cancelled"}:
+        logger.info("skipping terminal generation job %s with status %s", job_id, current_status)
+        return 0
     logger.info("dequeued generation job %s", job_id)
     return run_generation_subprocess(job_id, request_file, timeout=timeout)

--- a/backend/runtime/job_event_log.py
+++ b/backend/runtime/job_event_log.py
@@ -1,0 +1,50 @@
+"""Durable per-job event log shared by the API and Huey worker."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from backend.config import settings
+
+
+def event_log_dir() -> Path:
+    path = settings.runtime_dir / "job_events"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def event_log_path(job_id: str) -> Path:
+    return event_log_dir() / f"{job_id}.jsonl"
+
+
+def append_job_message(job_id: str, message: dict[str, Any]) -> None:
+    payload = dict(message)
+    payload.setdefault("job_id", job_id)
+    payload.setdefault("logged_at", time.time())
+    path = event_log_path(job_id)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, default=str) + "\n")
+        handle.flush()
+
+
+def read_messages_after(job_id: str, offset: int) -> tuple[int, list[dict[str, Any]]]:
+    path = event_log_path(job_id)
+    if not path.exists():
+        return offset, []
+    messages: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        handle.seek(offset)
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(message, dict):
+                messages.append(message)
+        return handle.tell(), messages

--- a/backend/runtime/job_event_monitor.py
+++ b/backend/runtime/job_event_monitor.py
@@ -64,6 +64,7 @@ async def sync_job_events_once(job_id: str) -> None:
         _offsets[job_id] = offset
         for message in messages:
             await _apply_message(job_id, message)
+        await _mark_lost_worker_if_needed(job_id)
 
 
 async def _apply_message(job_id: str, message: dict[str, Any]) -> None:
@@ -122,6 +123,32 @@ def _record_error(job_id: str, message: str) -> None:
     event = _ProgressEvent("error", "error", message, job.progress)
     for payload, updates in payloads_from_progress_event(job_id, job, event):
         session_manager.record_event(job_id, payload, **updates)
+
+
+async def _mark_lost_worker_if_needed(job_id: str) -> None:
+    job = session_manager.get_job(job_id)
+    if job is None or job.status in TERMINAL_STATUSES:
+        return
+    if getattr(job, "worker_backend", None) != "huey-sqlite":
+        return
+
+    from backend.runtime.worker_process_registry import (
+        has_job_process_record,
+        is_job_process_lost,
+        unregister_job_process,
+    )
+
+    has_record = await aoffload(has_job_process_record, job_id)
+    lost = await aoffload(is_job_process_lost, job_id)
+    if not has_record and job.status != "pending":
+        lost = True
+    if not lost:
+        return
+    await aoffload(unregister_job_process, job_id)
+    _record_error(
+        job_id,
+        "Generation worker process exited or was lost before reporting completion.",
+    )
 
 
 async def write_generation_request(job_id: str, request: Any) -> Path:

--- a/backend/runtime/job_event_monitor.py
+++ b/backend/runtime/job_event_monitor.py
@@ -1,0 +1,140 @@
+"""Bridge durable worker event logs back into live API session state."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from backend.config import settings
+from backend.runtime import aoffload
+from backend.runtime.job_event_log import read_messages_after
+from backend.runtime.job_request import serialize_generation_request
+from backend.session.manager import session_manager
+from backend.session.progress import payloads_from_progress_event
+
+
+logger = logging.getLogger(__name__)
+TERMINAL_STATUSES = {"complete", "error", "cancelled"}
+_offsets: dict[str, int] = {}
+_locks: dict[str, asyncio.Lock] = {}
+
+
+@dataclass
+class _ProgressEvent:
+    stage: str
+    status: str
+    message: str = ""
+    progress: float = 0.0
+    data: dict | None = None
+
+
+async def monitor_job_events(job_id: str) -> None:
+    while True:
+        await sync_job_events_once(job_id)
+        job = session_manager.get_job(job_id)
+        if job is None or job.status in TERMINAL_STATUSES:
+            return
+        await asyncio.sleep(0.25)
+
+
+def resume_provider_job_monitors() -> None:
+    for job in session_manager.list_jobs():
+        if job.status in TERMINAL_STATUSES:
+            continue
+        if job.worker_backend != "huey-sqlite":
+            continue
+        if session_manager.has_registered_task(job.id):
+            continue
+        task = asyncio.create_task(
+            monitor_job_events(job.id),
+            name=f"job-{job.id}-event-monitor",
+        )
+        session_manager.register_task(job.id, task)
+
+
+async def sync_job_events_once(job_id: str) -> None:
+    lock = _locks.setdefault(job_id, asyncio.Lock())
+    async with lock:
+        offset = _offsets.get(job_id, 0)
+        offset, messages = await aoffload(read_messages_after, job_id, offset)
+        _offsets[job_id] = offset
+        for message in messages:
+            await _apply_message(job_id, message)
+
+
+async def _apply_message(job_id: str, message: dict[str, Any]) -> None:
+    job = session_manager.get_job(job_id)
+    if job is None:
+        return
+    if job.status in TERMINAL_STATUSES:
+        return
+
+    msg_type = message.get("type")
+    if msg_type == "worker_stdout":
+        payload = message.get("payload")
+        if not isinstance(payload, str):
+            return
+        try:
+            worker_message = json.loads(payload)
+        except json.JSONDecodeError:
+            logger.warning("job %s worker emitted non-json stdout: %s", job_id, payload[:500])
+            return
+        await _apply_worker_message(job_id, worker_message)
+        return
+
+    if msg_type == "worker_timeout":
+        _record_error(job_id, str(message.get("message") or "Generation worker timed out."))
+        return
+
+    if msg_type == "worker_exit":
+        returncode = int(message.get("returncode", 0) or 0)
+        if returncode != 0:
+            _record_error(job_id, f"Generation worker exited with code {returncode}.")
+
+
+async def _apply_worker_message(job_id: str, message: dict[str, Any]) -> None:
+    if message.get("type") != "event" or not isinstance(message.get("event"), dict):
+        return
+    event_raw = message["event"]
+    event = _ProgressEvent(
+        stage=str(event_raw.get("stage") or "generation"),
+        status=str(event_raw.get("status") or "progress"),
+        message=str(event_raw.get("message") or ""),
+        progress=float(event_raw.get("progress", 0.0) or 0.0),
+        data=event_raw.get("data") if isinstance(event_raw.get("data"), dict) else None,
+    )
+    job = session_manager.get_job(job_id)
+    if job is None:
+        return
+    for payload, updates in payloads_from_progress_event(job_id, job, event):
+        session_manager.record_event(job_id, payload, **updates)
+        job = session_manager.get_job(job_id) or job
+
+
+def _record_error(job_id: str, message: str) -> None:
+    job = session_manager.get_job(job_id)
+    if job is None or job.status in TERMINAL_STATUSES:
+        return
+    event = _ProgressEvent("error", "error", message, job.progress)
+    for payload, updates in payloads_from_progress_event(job_id, job, event):
+        session_manager.record_event(job_id, payload, **updates)
+
+
+async def write_generation_request(job_id: str, request: Any) -> Path:
+    target_dir = settings.runtime_dir / "job_requests"
+    target = target_dir / f"{job_id}.json"
+    payload = {
+        "job_id": job_id,
+        "request": serialize_generation_request(request),
+    }
+
+    def _write() -> None:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    await aoffload(_write)
+    return target

--- a/backend/runtime/job_request.py
+++ b/backend/runtime/job_request.py
@@ -1,0 +1,22 @@
+"""Serialize generation requests for isolated workers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+
+def serialize_generation_request(request: Any) -> dict[str, Any]:
+    """Return a JSON-serializable GenerationRequest payload."""
+    if is_dataclass(request):
+        raw = asdict(request)
+    else:
+        raw = dict(vars(request))
+
+    for key, value in list(raw.items()):
+        if isinstance(value, Path):
+            raw[key] = str(value)
+        elif hasattr(value, "model_dump"):
+            raw[key] = value.model_dump(exclude_none=True)
+    return raw

--- a/backend/runtime/worker_process_registry.py
+++ b/backend/runtime/worker_process_registry.py
@@ -1,0 +1,85 @@
+"""Small file-backed registry for active isolated job processes."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import psutil
+
+from backend.config import settings
+
+
+def _registry_dir() -> Path:
+    path = settings.runtime_dir / "job_processes"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def process_file(job_id: str) -> Path:
+    return _registry_dir() / f"{job_id}.json"
+
+
+def register_job_process(job_id: str, pid: int) -> None:
+    process_file(job_id).write_text(
+        json.dumps({"job_id": job_id, "pid": pid, "started_at": time.time()}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def unregister_job_process(job_id: str) -> None:
+    try:
+        process_file(job_id).unlink()
+    except FileNotFoundError:
+        pass
+
+
+def get_job_process_pid(job_id: str) -> int | None:
+    try:
+        payload = json.loads(process_file(job_id).read_text(encoding="utf-8"))
+        return int(payload["pid"])
+    except (FileNotFoundError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def is_job_process_alive(job_id: str) -> bool:
+    pid = get_job_process_pid(job_id)
+    return bool(pid and psutil.pid_exists(pid))
+
+
+def terminate_job_process_tree(job_id: str) -> bool:
+    pid = get_job_process_pid(job_id)
+    if not pid:
+        return False
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        unregister_job_process(job_id)
+        return False
+
+    children = parent.children(recursive=True)
+    for proc in children:
+        _terminate(proc)
+    _terminate(parent)
+    _, alive = psutil.wait_procs([parent, *children], timeout=5.0)
+    for proc in alive:
+        _kill(proc)
+    if alive:
+        psutil.wait_procs(alive, timeout=2.0)
+    unregister_job_process(job_id)
+    return True
+
+
+def _terminate(proc: psutil.Process) -> None:
+    try:
+        proc.terminate()
+    except psutil.Error:
+        pass
+
+
+def _kill(proc: psutil.Process) -> None:
+    try:
+        proc.kill()
+    except psutil.Error:
+        pass

--- a/backend/runtime/worker_process_registry.py
+++ b/backend/runtime/worker_process_registry.py
@@ -43,6 +43,15 @@ def get_job_process_pid(job_id: str) -> int | None:
         return None
 
 
+def has_job_process_record(job_id: str) -> bool:
+    return process_file(job_id).exists()
+
+
+def is_job_process_lost(job_id: str) -> bool:
+    pid = get_job_process_pid(job_id)
+    return bool(pid and not psutil.pid_exists(pid))
+
+
 def is_job_process_alive(job_id: str) -> bool:
     pid = get_job_process_pid(job_id)
     return bool(pid and psutil.pid_exists(pid))

--- a/backend/session/manager.py
+++ b/backend/session/manager.py
@@ -202,6 +202,7 @@ class SessionManager:
         return bool(task and not task.done())
 
     def cancel_job(self, job_id: str) -> bool:
+        job = self._jobs.get(job_id)
         try:
             from backend.runtime.worker_process_registry import terminate_job_process_tree
 
@@ -210,6 +211,15 @@ class SessionManager:
                 return True
         except Exception:
             logger.exception("failed to terminate isolated worker for job %s", job_id)
+
+        if job is not None and job.worker_backend == "huey-sqlite":
+            # Huey jobs are supervised by a monitor task. Cancelling only that
+            # task leaves the UI stuck unless the job itself becomes terminal.
+            self.mark_job_cancelled(job_id)
+            task = self._tasks.get(job_id)
+            if task is not None and not task.done():
+                task.cancel()
+            return True
 
         # Prefer the scheduler when it's been wired in: it knows about both
         # running tasks *and* still-queued ones (which we can't reach via

--- a/backend/session/manager.py
+++ b/backend/session/manager.py
@@ -80,6 +80,7 @@ class Job:
     language: str | None = None
     detail_level: str | None = None
     instruction: str | None = None
+    worker_backend: str | None = None
     # Bounded ring buffer of recent events with monotonically increasing
     # ``seq`` ids. Persisted to disk so a reconnecting client can ask for
     # everything after its last seen seq.
@@ -171,10 +172,20 @@ class SessionManager:
     def get_job(self, job_id: str) -> Job | None:
         return self._jobs.get(job_id)
 
+    def list_jobs(self) -> list[Job]:
+        return list(self._jobs.values())
+
     def is_job_running(self, job_id: str) -> bool:
-        """True if there is a live asyncio task for *job_id*."""
+        """True if there is a live monitor task or isolated worker process."""
         task = self._tasks.get(job_id)
-        return bool(task and not task.done())
+        if task and not task.done():
+            return True
+        try:
+            from backend.runtime.worker_process_registry import is_job_process_alive
+
+            return is_job_process_alive(job_id)
+        except Exception:
+            return False
 
     def register_task(self, job_id: str, task: asyncio.Task[Any]) -> None:
         self._tasks[job_id] = task
@@ -186,7 +197,20 @@ class SessionManager:
 
         task.add_done_callback(_cleanup)
 
+    def has_registered_task(self, job_id: str) -> bool:
+        task = self._tasks.get(job_id)
+        return bool(task and not task.done())
+
     def cancel_job(self, job_id: str) -> bool:
+        try:
+            from backend.runtime.worker_process_registry import terminate_job_process_tree
+
+            if terminate_job_process_tree(job_id):
+                self.mark_job_cancelled(job_id)
+                return True
+        except Exception:
+            logger.exception("failed to terminate isolated worker for job %s", job_id)
+
         # Prefer the scheduler when it's been wired in: it knows about both
         # running tasks *and* still-queued ones (which we can't reach via
         # ``self._tasks``). Falls through to legacy task cancellation when
@@ -403,6 +427,11 @@ class SessionManager:
         for job in self._jobs.values():
             if job.status in terminal:
                 continue
+            # Provider jobs are now backed by the local SQLiteHuey queue and
+            # durable event logs, so an API reload can resume monitoring them.
+            # Agent jobs keep live SDK sessions in-process and cannot recover.
+            if job.worker_backend == "huey-sqlite":
+                continue
             if job.status in running_states or job.status not in terminal:
                 job.status = "error"
                 if not job.error:
@@ -557,6 +586,7 @@ class SessionManager:
                     language=raw_job.get("language"),
                     detail_level=raw_job.get("detail_level"),
                     instruction=raw_job.get("instruction"),
+                    worker_backend=raw_job.get("worker_backend"),
                     events=events[-EVENT_RING_SIZE:],
                     last_seq=last_seq,
                     agent_session_id=raw_job.get("agent_session_id"),

--- a/backend/session/progress.py
+++ b/backend/session/progress.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from .manager import Job
+if TYPE_CHECKING:
+    from .manager import Job
 
 PIPELINE_STAGES = (
     "agent",

--- a/backend/workers/__init__.py
+++ b/backend/workers/__init__.py
@@ -1,0 +1,1 @@
+"""Worker process entrypoints."""

--- a/backend/workers/consumer.py
+++ b/backend/workers/consumer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 
 from huey.consumer import Consumer
 
@@ -11,15 +12,41 @@ from backend.queue.broker import huey
 import backend.queue.tasks  # noqa: F401 - task registration side effect
 
 
+def _auto_worker_count() -> int:
+    cpu_count = os.cpu_count() or 2
+    cpu_budget = 1 if cpu_count < 8 else 2 if cpu_count < 16 else 3
+    memory_budget = 2
+    try:
+        import psutil
+
+        total_gb = psutil.virtual_memory().total / (1024 ** 3)
+        if total_gb < 12:
+            memory_budget = 1
+        elif total_gb >= 32:
+            memory_budget = 3
+    except Exception:
+        memory_budget = 1
+    return max(1, min(cpu_budget, memory_budget, 4))
+
+
+def worker_count() -> int:
+    configured = int(settings.generation_worker_concurrency or 0)
+    if configured > 0:
+        return max(1, min(configured, 8))
+    return _auto_worker_count()
+
+
 def main() -> None:
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
     settings.runtime_dir.mkdir(parents=True, exist_ok=True)
+    workers = worker_count()
+    logging.info("starting Huey consumer with %s worker slot(s)", workers)
     consumer = Consumer(
         huey,
-        workers=1,
+        workers=workers,
         worker_type="thread",
         periodic=False,
     )

--- a/backend/workers/consumer.py
+++ b/backend/workers/consumer.py
@@ -1,0 +1,30 @@
+"""Run the local Huey consumer."""
+
+from __future__ import annotations
+
+import logging
+
+from huey.consumer import Consumer
+
+from backend.config import settings
+from backend.queue.broker import huey
+import backend.queue.tasks  # noqa: F401 - task registration side effect
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    settings.runtime_dir.mkdir(parents=True, exist_ok=True)
+    consumer = Consumer(
+        huey,
+        workers=1,
+        worker_type="thread",
+        periodic=False,
+    )
+    consumer.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/workers/generation_worker.py
+++ b/backend/workers/generation_worker.py
@@ -1,0 +1,104 @@
+"""Isolated generation worker.
+
+The API process launches this module in a separate Python process for normal
+provider-backed generation. Progress is streamed back as JSON Lines on stdout;
+all diagnostics go to stderr so the parent can keep parsing stdout safely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from backend.config import settings
+from backend.runtime.offload import init_offload, shutdown_offload
+
+
+logger = logging.getLogger(__name__)
+
+
+def _emit(message: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(message, ensure_ascii=False, default=str) + "\n")
+    sys.stdout.flush()
+
+
+def _event_payload(event: Any) -> dict[str, Any]:
+    return {
+        "stage": event.stage,
+        "status": event.status,
+        "message": event.message,
+        "progress": event.progress,
+        "data": event.data,
+    }
+
+
+def _request_from_payload(payload: dict[str, Any]) -> Any:
+    from backend.api.schemas import ResearchConfig
+    from backend.orchestrator.pipeline import GenerationRequest
+
+    data = dict(payload["request"])
+    data["file_path"] = Path(data["file_path"])
+    if isinstance(data.get("research_config"), dict):
+        data["research_config"] = ResearchConfig(**data["research_config"])
+    return GenerationRequest(**data)
+
+
+async def _run(request_path: Path) -> int:
+    from backend.orchestrator.pipeline import ProgressEvent, run_pipeline
+    from backend.session.progress import describe_exception
+    from backend.usage.tracker import set_usage_context
+
+    payload = json.loads(request_path.read_text(encoding="utf-8"))
+    job_id = str(payload["job_id"])
+    request = _request_from_payload(payload)
+    set_usage_context(job_id=job_id)
+
+    try:
+        async for event in run_pipeline(request):
+            _emit({"type": "event", "event": _event_payload(event)})
+        _emit({"type": "done"})
+        return 0
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.exception("generation worker failed for job %s", job_id)
+        _emit(
+            {
+                "type": "event",
+                "event": _event_payload(
+                    ProgressEvent(
+                        "error",
+                        "error",
+                        describe_exception(exc, "Generation failed"),
+                        0.0,
+                    )
+                ),
+            }
+        )
+        return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--request", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s:%(name)s:%(message)s",
+        stream=sys.stderr,
+    )
+    init_offload(settings.io_pool_workers)
+    try:
+        return asyncio.run(_run(args.request))
+    finally:
+        shutdown_offload(wait=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/workers/subprocess_runner.py
+++ b/backend/workers/subprocess_runner.py
@@ -1,0 +1,104 @@
+"""Synchronous runner used by the Huey consumer to supervise job children."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from backend.runtime.job_event_log import append_job_message
+from backend.runtime.worker_process_registry import (
+    register_job_process,
+    terminate_job_process_tree,
+    unregister_job_process,
+)
+
+
+logger = logging.getLogger(__name__)
+_IS_WINDOWS = sys.platform.startswith("win")
+
+
+def run_generation_subprocess(job_id: str, request_file: str, timeout: float | None = None) -> int:
+    """Run the isolated generation worker and copy its stdout to the event log."""
+    argv = [
+        sys.executable,
+        "-m",
+        "backend.workers.generation_worker",
+        "--request",
+        request_file,
+    ]
+    creationflags = 0
+    popen_kwargs: dict = {}
+    if _IS_WINDOWS:
+        creationflags = 0x00000200 | 0x08000000  # CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+
+    proc = subprocess.Popen(
+        argv,
+        cwd=str(Path.cwd()),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        bufsize=1,
+        creationflags=creationflags,
+        env=env,
+        **popen_kwargs,
+    )
+    register_job_process(job_id, proc.pid)
+    append_job_message(job_id, {"type": "worker_started", "pid": proc.pid})
+    stdout_thread = threading.Thread(target=_copy_stdout, args=(job_id, proc), daemon=True)
+    stderr_thread = threading.Thread(target=_copy_stderr, args=(job_id, proc), daemon=True)
+    stdout_thread.start()
+    stderr_thread.start()
+
+    deadline = time.monotonic() + timeout if timeout and timeout > 0 else None
+    try:
+        while True:
+            returncode = proc.poll()
+            if returncode is not None:
+                stdout_thread.join(timeout=2.0)
+                stderr_thread.join(timeout=2.0)
+                append_job_message(job_id, {"type": "worker_exit", "returncode": returncode})
+                return returncode
+            if deadline is not None and time.monotonic() >= deadline:
+                terminate_job_process_tree(job_id)
+                append_job_message(
+                    job_id,
+                    {
+                        "type": "worker_timeout",
+                        "message": f"Job exceeded timeout of {timeout}s",
+                    },
+                )
+                return -1
+            time.sleep(0.25)
+    finally:
+        unregister_job_process(job_id)
+
+
+def _copy_stdout(job_id: str, proc: subprocess.Popen[str]) -> None:
+    if proc.stdout is None:
+        return
+    for line in proc.stdout:
+        text = line.strip()
+        if text:
+            append_job_message(job_id, {"type": "worker_stdout", "payload": text})
+
+
+def _copy_stderr(job_id: str, proc: subprocess.Popen[str]) -> None:
+    if proc.stderr is None:
+        return
+    for line in proc.stderr:
+        text = line.rstrip()
+        if text:
+            logger.info("job %s worker: %s", job_id, text)

--- a/frontend/src/hooks/useGeneration.ts
+++ b/frontend/src/hooks/useGeneration.ts
@@ -130,7 +130,7 @@ interface GenerationState {
   cancelCurrentRun: () => Promise<void>;
   interruptCurrentAgent: () => Promise<void>;
   sendAgentFeedback: (message: string, jobId?: string) => Promise<void>;
-  connect: (jobId: string) => void;
+  connect: (jobId: string, options?: { replayFromStart?: boolean }) => void;
   hydrateResult: (jobId: string) => Promise<void>;
   refreshHistoryStatuses: () => Promise<void>;
   resumeCurrentRun: (targetJobId?: string) => Promise<boolean>;
@@ -501,6 +501,7 @@ function serializeRunsForStorage(runs: Record<string, RunSnapshot>) {
         error: run.error,
         currentRunConfig: run.currentRunConfig,
         connectionStatus: "disconnected" as const,
+        lastSeq: run.lastSeq,
       } satisfies StoredRunSnapshot,
     ]),
   );
@@ -523,6 +524,7 @@ function normalizeStoredRun(jobId: string, run?: Partial<RunSnapshot>): RunSnaps
     result: undefined,
     currentRunConfig: run?.currentRunConfig,
     connectionStatus: "disconnected",
+    lastSeq: run?.lastSeq,
     enrichmentStats: run?.enrichmentStats,
   });
 }
@@ -928,11 +930,20 @@ export const useGeneration = create<GenerationState>()(
               };
             });
             get().syncHistory(jobId);
+            if (!get().socketsByJob[jobId]?.isOpen()) {
+              get().connect(jobId);
+            }
             return;
           }
           if (response.status === "queued") {
+            const terminalSocket = get().socketsByJob[jobId];
+            terminalSocket?.close();
             set((state) => {
               const currentRun = state.runs[jobId] ?? createRunSnapshot(jobId);
+              const nextSockets = { ...state.socketsByJob };
+              if (nextSockets[jobId] === terminalSocket) {
+                delete nextSockets[jobId];
+              }
               const nextJob = currentRun.job
                 ? {
                     ...currentRun.job,
@@ -955,9 +966,11 @@ export const useGeneration = create<GenerationState>()(
                   ...state.runs,
                   [jobId]: updatedRun,
                 },
+                socketsByJob: nextSockets,
               };
             });
             get().syncHistory(jobId);
+            get().connect(jobId);
           }
         } catch (error) {
           set((state) => {
@@ -985,10 +998,16 @@ export const useGeneration = create<GenerationState>()(
           throw error;
         }
       },
-      connect(jobId) {
+      connect(jobId, options) {
         const existingSocket = get().socketsByJob[jobId];
         const existingRun = get().runs[jobId];
-        const initialSeq = Math.max(existingRun?.lastSeq ?? 0, seenSeqByJob.get(jobId) ?? 0);
+        const replayFromStart = options?.replayFromStart === true;
+        if (replayFromStart) {
+          seenSeqByJob.delete(jobId);
+        }
+        const initialSeq = replayFromStart
+          ? 0
+          : Math.max(existingRun?.lastSeq ?? 0, seenSeqByJob.get(jobId) ?? 0);
         if (initialSeq > 0) {
           seenSeqByJob.set(jobId, initialSeq);
         }
@@ -1071,20 +1090,24 @@ export const useGeneration = create<GenerationState>()(
                     : event.data.agent_interrupt === true
                       ? "pausing"
                       : undefined;
+              const terminalStatus =
+                event.type === "complete" || (event.stage === "export" && event.status === "complete")
+                  ? "complete"
+                  : event.type === "error" || event.status === "error"
+                    ? event.stage === "cancelled"
+                      ? "cancelled"
+                      : "error"
+                    : undefined;
               const nextJob: JobStatus = {
                 status:
-                  event.type === "complete"
-                    ? "complete"
-                    : event.type === "error"
-                      ? "error"
-                      : agentLifecycleStatus ?? displayStage,
+                  terminalStatus ?? agentLifecycleStatus ?? displayStage,
                 progress: event.progress,
                 message: event.message,
                 slides_completed: slidesCompleted,
                 total_slides: event.total_slides,
                 output_path:
                   typeof event.data.output_path === "string" ? event.data.output_path : currentRun.job?.output_path,
-                error: event.type === "error" ? event.message : undefined,
+                error: terminalStatus === "error" ? event.message : undefined,
                 provider: currentRun.job?.provider,
                 model: currentRun.job?.model,
                 base_url: currentRun.job?.base_url,
@@ -1138,7 +1161,7 @@ export const useGeneration = create<GenerationState>()(
                     : pickSelectedSlide(slides, currentRun.selectedSlide),
                 logs,
                 agentMessages,
-                error: event.type === "error" ? event.message : undefined,
+                error: terminalStatus === "error" ? event.message : undefined,
                 connectionStatus: FINAL_JOB_STATUSES.has(nextJob.status) ? "disconnected" : currentRun.connectionStatus,
                 lastSeq: typeof seq === "number" && seq > 0 ? Math.max(currentRun.lastSeq ?? 0, seq) : currentRun.lastSeq,
               };
@@ -1229,7 +1252,7 @@ export const useGeneration = create<GenerationState>()(
               const run = state.runs[jobId] ?? createRunSnapshot(jobId);
               const updatedRun = { ...run, connectionStatus: willReconnect ? "connecting" as const : "disconnected" as const };
               const nextSockets = { ...state.socketsByJob };
-              if (!willReconnect) {
+              if (!willReconnect && nextSockets[jobId] === socket) {
                 delete nextSockets[jobId];
               }
               return {

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Bot, CircleCheck, Database, FileText, Info, Loader2, MessageSquareText, Sparkles, Type, Wand2, X } from "lucide-react";
 import { Layout } from "../components/layout/Layout";
@@ -87,9 +87,9 @@ export function ResultPage() {
   const [remoteCriticEvents, setRemoteCriticEvents] = useState<CriticEvent[] | null>(null);
   const resolvedRun = jobId ? runs[jobId] : undefined;
   const isActiveJob = jobId === activeJobId;
-  const logs = isActiveJob ? globalLogs : (resolvedRun?.logs ?? []);
-  const agentMessages = isActiveJob ? globalAgentMessages : (resolvedRun?.agentMessages ?? []);
-  const localCritic = isActiveJob ? globalCriticEvents : (resolvedRun?.criticEvents ?? []);
+  const logs = resolvedRun?.logs ?? (isActiveJob ? globalLogs : []);
+  const agentMessages = resolvedRun?.agentMessages ?? (isActiveJob ? globalAgentMessages : []);
+  const localCritic = resolvedRun?.criticEvents ?? (isActiveJob ? globalCriticEvents : []);
   const criticEvents = localCritic.length > 0 ? localCritic : (remoteCriticEvents ?? []);
   // Direct-bind the global error-store setters so we can mirror local
   // page errors (load / refine / reexport / failed-job) into the global
@@ -146,10 +146,10 @@ export function ResultPage() {
       : job?.provider?.startsWith("agent:")
         ? job.provider.slice("agent:".length)
         : "claude_code");
+  const requestedAgentHistoryForJob = useRef<string | null>(null);
 
   const handleAgentResultSend = async (text: string) => {
     if (!jobId) return;
-    connect(jobId);
     await sendAgentFeedback(text, jobId);
   };
   const pptistPreviewRevision = useMemo(
@@ -171,6 +171,21 @@ export function ResultPage() {
       setJob(liveJob);
     }
   }, [activeJobId, jobId, liveJob, liveResult]);
+
+  useEffect(() => {
+    if (!jobId || !isAgentResult || resultRunStatus !== "complete") {
+      return;
+    }
+    if (requestedAgentHistoryForJob.current === jobId) {
+      return;
+    }
+    const run = useGeneration.getState().runs[jobId];
+    if ((run?.agentMessages.length ?? 0) > 0 && typeof run?.lastSeq === "number") {
+      return;
+    }
+    requestedAgentHistoryForJob.current = jobId;
+    connect(jobId, { replayFromStart: (run?.agentMessages.length ?? 0) === 0 });
+  }, [connect, isAgentResult, jobId, resultRunStatus]);
 
   useEffect(() => {
     let cancelled = false;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
     "aiofiles>=24.0.0",
     "httpx>=0.27.0",
     "python-dotenv>=1.0.0",
+    "psutil>=5.9.0",
+    "huey>=3.0.1",
+    "peewee>=4.0.6",
 ]
 
 [project.optional-dependencies]

--- a/start-dev.bat
+++ b/start-dev.bat
@@ -40,15 +40,9 @@ if not exist "%FRONTEND_DIR%\node_modules" (
   popd
 )
 
-echo ==> Starting backend
-start "Paper PPT Agent Backend" cmd /k "cd /d ""%ROOT%"" && set PYTHONUNBUFFERED=1 && uv run python -m uvicorn backend.app:app --host 127.0.0.1 --port 8000 --reload --reload-dir backend --reload-include=*.py"
-
-echo ==> Starting frontend
-start "Paper PPT Agent Frontend" cmd /k "cd /d ""%FRONTEND_DIR%"" && npm run dev -- --host 127.0.0.1 --port 5173 --strictPort --open"
-
-echo.
-echo Paper PPT Agent is starting:
-echo   Backend:  http://127.0.0.1:8000
-echo   Frontend: %FRONTEND_URL%
+echo ==> Starting Paper PPT Agent in this window
+cd /d "%ROOT%"
+set PYTHONUNBUFFERED=1
+call uv run python -m backend.dev_launcher
 
 endlocal

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -3,7 +3,6 @@ set -eu
 
 ROOT="$(CDPATH= cd "$(dirname "$0")" && pwd)"
 FRONTEND_DIR="$ROOT/frontend"
-FRONTEND_URL="http://127.0.0.1:5173"
 
 if ! command -v uv >/dev/null 2>&1; then
   echo "uv was not found in the current shell environment."
@@ -27,36 +26,6 @@ if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
   npm install
 fi
 
-cleanup() {
-  if [ -n "${BACKEND_PID:-}" ] && kill -0 "$BACKEND_PID" >/dev/null 2>&1; then
-    kill "$BACKEND_PID" >/dev/null 2>&1 || true
-  fi
-  if [ -n "${FRONTEND_PID:-}" ] && kill -0 "$FRONTEND_PID" >/dev/null 2>&1; then
-    kill "$FRONTEND_PID" >/dev/null 2>&1 || true
-  fi
-}
-trap cleanup EXIT INT TERM
-
-echo "==> Starting backend"
+echo "==> Starting Paper PPT Agent in this terminal"
 cd "$ROOT"
-PYTHONUNBUFFERED=1 uv run python -m uvicorn backend.app:app \
-  --host 127.0.0.1 \
-  --port 8000 \
-  --reload \
-  --reload-dir backend \
-  --reload-include='*.py' &
-BACKEND_PID=$!
-
-echo "==> Starting frontend"
-cd "$FRONTEND_DIR"
-npm run dev -- --host 127.0.0.1 --port 5173 --strictPort --open &
-FRONTEND_PID=$!
-
-echo
-echo "Paper PPT Agent is starting:"
-echo "  Backend:  http://127.0.0.1:8000"
-echo "  Frontend: $FRONTEND_URL"
-echo
-echo "Press Ctrl+C to stop both services."
-
-wait "$BACKEND_PID" "$FRONTEND_PID"
+PYTHONUNBUFFERED=1 uv run python -m backend.dev_launcher

--- a/tests/test_agent_asset_extractor.py
+++ b/tests/test_agent_asset_extractor.py
@@ -98,3 +98,85 @@ def test_pdf_extractor_records_caption_page_and_href(tmp_path: Path) -> None:
     assert records[0].href.startswith("../source_assets/images/")
     assert records[0].natural_width > 0
     assert "[[FIG:" in result["paper_markdown"]
+
+
+def test_pdf_caption_crop_separates_stacked_figures() -> None:
+    try:
+        import fitz
+    except Exception:
+        return
+
+    extractor = _load_extractor()
+    captions = [
+        {"text": "Figure 1. Upper trend.", "rect": fitz.Rect(100, 200, 300, 218)},
+        {"text": "Figure 2. Lower trend.", "rect": fitz.Rect(100, 450, 300, 468)},
+    ]
+    clip = extractor._caption_region_clip(
+        fitz.Rect(0, 0, 600, 800),
+        captions[1]["rect"],
+        [{"text": item["text"], "rect": item["rect"], "char_count": len(item["text"])} for item in captions],
+        captions,
+    )
+
+    assert clip is not None
+    assert clip.y0 >= captions[0]["rect"].y1 + 10
+
+
+def test_pdf_caption_crop_expands_sparse_full_page_figure() -> None:
+    try:
+        import fitz
+    except Exception:
+        return
+
+    extractor = _load_extractor()
+    caption = {"text": "Figure 5. Annual distribution.", "rect": fitz.Rect(100, 590, 350, 610)}
+    blocks = [
+        {"text": "Journal header", "rect": fitz.Rect(40, 60, 500, 84), "char_count": 14},
+        {"text": caption["text"], "rect": caption["rect"], "char_count": len(caption["text"])},
+    ]
+    clip = extractor._caption_region_clip(
+        fitz.Rect(0, 0, 600, 800),
+        caption["rect"],
+        blocks,
+        [caption],
+    )
+
+    assert clip is not None
+    assert clip.y0 == 92
+    assert clip.y0 < caption["rect"].y0 - extractor.PDF_CAPTION_MAX_GAP
+
+
+def test_pdf_table_region_drops_caption_and_preceding_content() -> None:
+    try:
+        import fitz
+    except Exception:
+        return
+
+    extractor = _load_extractor()
+
+    class _Table:
+        bbox = (50, 90, 500, 380)
+
+    class _Finder:
+        tables = [_Table()]
+
+    class _Page:
+        rect = fitz.Rect(0, 0, 600, 800)
+
+        @staticmethod
+        def find_tables():
+            return _Finder()
+
+    caption = {"text": "Table 1. Satellite imagery.", "rect": fitz.Rect(160, 120, 360, 140)}
+    regions = extractor._pdf_table_regions(_Page(), [caption])
+
+    assert len(regions) == 1
+    clip, selected_caption = regions[0]
+    assert selected_caption == caption["text"]
+    assert clip.y0 >= caption["rect"].y1 + 12
+
+
+def test_pdf_caption_normalizes_joined_chinese_index_and_year() -> None:
+    extractor = _load_extractor()
+
+    assert extractor._normalize_pdf_caption("图 ５２０００ ２０１５ 年频率分布") == "图 ５ ２０００ ２０１５ 年频率分布"

--- a/tests/test_agent_preview_resilience.py
+++ b/tests/test_agent_preview_resilience.py
@@ -79,6 +79,20 @@ def test_agent_research_policy_keeps_query_choice_with_agent() -> None:
     assert "backend does not preselect" in policy["query_rule"]
 
 
+def test_empty_agent_output_message_reports_stray_svg(tmp_path: Path) -> None:
+    stray_dir = tmp_path / "nested"
+    stray_dir.mkdir()
+    (stray_dir / "slide_001.svg").write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+        encoding="utf-8",
+    )
+
+    message = agent_pipeline._empty_agent_output_message(tmp_path)
+
+    assert "completed without producing SVG slides" in message
+    assert "nested/slide_001.svg" in message
+
+
 def _write_research_gated_task(project_dir: Path) -> None:
     (project_dir / "agent_task.json").write_text(
         json.dumps(

--- a/tests/test_huey_cancel.py
+++ b/tests/test_huey_cancel.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from backend.session.manager import Job, SessionManager
+from backend.queue import tasks
+
+
+def test_huey_job_cancel_marks_terminal(monkeypatch) -> None:
+    manager = object.__new__(SessionManager)
+    job = Job(
+        id="job-1",
+        session_id="session-1",
+        status="research",
+        worker_backend="huey-sqlite",
+        message="Generating manuscript from brief",
+    )
+    manager._jobs = {job.id: job}
+    manager._tasks = {}
+    manager._ws_queues = {}
+    monkeypatch.setattr(manager, "_persist_state", lambda: None)
+    monkeypatch.setattr(
+        "backend.runtime.worker_process_registry.terminate_job_process_tree",
+        lambda _job_id: False,
+    )
+
+    assert manager.cancel_job(job.id)
+
+    cancelled = manager.get_job(job.id)
+    assert cancelled is not None
+    assert cancelled.status == "cancelled"
+
+
+def test_cancelled_queued_job_is_not_started(monkeypatch) -> None:
+    monkeypatch.setattr(tasks, "_persisted_job_status", lambda _job_id: "cancelled")
+    called = False
+
+    def fake_run(*_args, **_kwargs) -> int:
+        nonlocal called
+        called = True
+        return 1
+
+    monkeypatch.setattr(tasks, "run_generation_subprocess", fake_run)
+
+    assert tasks.run_generation_job.call_local("job-1", "request.json") == 0
+    assert not called

--- a/tests/test_job_event_monitor.py
+++ b/tests/test_job_event_monitor.py
@@ -31,6 +31,7 @@ def _job() -> SimpleNamespace:
         total_slides=0,
         output_path=None,
         project_dir=None,
+        worker_backend="huey-sqlite",
     )
 
 
@@ -49,8 +50,12 @@ async def test_sync_job_events_applies_worker_progress(monkeypatch) -> None:
         },
     }
 
-    async def fake_aoffload(_fn, _job_id, _offset):
-        return 10, [{"type": "worker_stdout", "payload": json.dumps(worker_payload)}]
+    async def fake_aoffload(fn, *args):
+        if getattr(fn, "__name__", "") == "read_messages_after":
+            return 10, [{"type": "worker_stdout", "payload": json.dumps(worker_payload)}]
+        if getattr(fn, "__name__", "") == "has_job_process_record":
+            return True
+        return False
 
     monkeypatch.setattr(job_event_monitor, "session_manager", manager)
     monkeypatch.setattr(job_event_monitor, "aoffload", fake_aoffload)
@@ -69,8 +74,10 @@ async def test_sync_job_events_marks_worker_exit_error(monkeypatch) -> None:
     job = _job()
     manager = _Manager(job)
 
-    async def fake_aoffload(_fn, _job_id, _offset):
-        return 10, [{"type": "worker_exit", "returncode": 7}]
+    async def fake_aoffload(fn, *args):
+        if getattr(fn, "__name__", "") == "read_messages_after":
+            return 10, [{"type": "worker_exit", "returncode": 7}]
+        return False
 
     monkeypatch.setattr(job_event_monitor, "session_manager", manager)
     monkeypatch.setattr(job_event_monitor, "aoffload", fake_aoffload)
@@ -80,3 +87,52 @@ async def test_sync_job_events_marks_worker_exit_error(monkeypatch) -> None:
 
     assert job.status == "error"
     assert "exited with code 7" in job.error
+
+
+@pytest.mark.asyncio
+async def test_sync_job_events_marks_lost_worker_error(monkeypatch) -> None:
+    job = _job()
+    job.status = "research"
+    job.progress = 0.24
+    manager = _Manager(job)
+
+    async def fake_aoffload(fn, *args):
+        if getattr(fn, "__name__", "") == "read_messages_after":
+            return 10, []
+        if getattr(fn, "__name__", "") == "is_job_process_lost":
+            return True
+        return None
+
+    monkeypatch.setattr(job_event_monitor, "session_manager", manager)
+    monkeypatch.setattr(job_event_monitor, "aoffload", fake_aoffload)
+    job_event_monitor._offsets.pop("job-3", None)
+
+    await job_event_monitor.sync_job_events_once("job-3")
+
+    assert job.status == "error"
+    assert "worker process" in job.error
+
+
+@pytest.mark.asyncio
+async def test_sync_job_events_marks_missing_worker_record_error(monkeypatch) -> None:
+    job = _job()
+    job.status = "research"
+    manager = _Manager(job)
+
+    async def fake_aoffload(fn, *args):
+        if getattr(fn, "__name__", "") == "read_messages_after":
+            return 10, []
+        if getattr(fn, "__name__", "") == "has_job_process_record":
+            return False
+        if getattr(fn, "__name__", "") == "is_job_process_lost":
+            return False
+        return None
+
+    monkeypatch.setattr(job_event_monitor, "session_manager", manager)
+    monkeypatch.setattr(job_event_monitor, "aoffload", fake_aoffload)
+    job_event_monitor._offsets.pop("job-4", None)
+
+    await job_event_monitor.sync_job_events_once("job-4")
+
+    assert job.status == "error"
+    assert "worker process" in job.error

--- a/tests/test_job_event_monitor.py
+++ b/tests/test_job_event_monitor.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from backend.runtime import job_event_monitor
+
+
+class _Manager:
+    def __init__(self, job: SimpleNamespace) -> None:
+        self.job = job
+        self.events: list[dict] = []
+
+    def get_job(self, _job_id: str) -> SimpleNamespace:
+        return self.job
+
+    def record_event(self, _job_id: str, payload: dict, **updates: object) -> None:
+        self.events.append(payload)
+        for key, value in updates.items():
+            setattr(self.job, key, value)
+
+
+def _job() -> SimpleNamespace:
+    return SimpleNamespace(
+        status="pending",
+        progress=0.0,
+        message="",
+        slides_completed=0,
+        total_slides=0,
+        output_path=None,
+        project_dir=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_job_events_applies_worker_progress(monkeypatch) -> None:
+    job = _job()
+    manager = _Manager(job)
+    worker_payload = {
+        "type": "event",
+        "event": {
+            "stage": "parsing",
+            "status": "started",
+            "message": "Parsing paper...",
+            "progress": 0.1,
+            "data": {"project_dir": "workspace-a"},
+        },
+    }
+
+    async def fake_aoffload(_fn, _job_id, _offset):
+        return 10, [{"type": "worker_stdout", "payload": json.dumps(worker_payload)}]
+
+    monkeypatch.setattr(job_event_monitor, "session_manager", manager)
+    monkeypatch.setattr(job_event_monitor, "aoffload", fake_aoffload)
+    job_event_monitor._offsets.pop("job-1", None)
+
+    await job_event_monitor.sync_job_events_once("job-1")
+
+    assert job.status == "parsing"
+    assert job.progress == 0.1
+    assert job.project_dir == "workspace-a"
+    assert manager.events[0]["message"] == "Parsing paper..."
+
+
+@pytest.mark.asyncio
+async def test_sync_job_events_marks_worker_exit_error(monkeypatch) -> None:
+    job = _job()
+    manager = _Manager(job)
+
+    async def fake_aoffload(_fn, _job_id, _offset):
+        return 10, [{"type": "worker_exit", "returncode": 7}]
+
+    monkeypatch.setattr(job_event_monitor, "session_manager", manager)
+    monkeypatch.setattr(job_event_monitor, "aoffload", fake_aoffload)
+    job_event_monitor._offsets.pop("job-2", None)
+
+    await job_event_monitor.sync_job_events_once("job-2")
+
+    assert job.status == "error"
+    assert "exited with code 7" in job.error

--- a/tests/test_llm_retry.py
+++ b/tests/test_llm_retry.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from backend.llm.retry import _is_retryable
+
+
+class APIError(RuntimeError):
+    pass
+
+
+def test_socket_closed_api_error_is_retryable() -> None:
+    exc = APIError(
+        "API Error: The socket connection was closed unexpectedly. "
+        "For more information, pass `verbose: true` in the second argument to fetch()"
+    )
+
+    assert _is_retryable(exc)
+
+
+def test_nested_connection_reset_is_retryable() -> None:
+    exc = RuntimeError("wrapper")
+    exc.__cause__ = ConnectionResetError("read ECONNRESET")
+
+    assert _is_retryable(exc)

--- a/tests/test_pdf_figure_identity.py
+++ b/tests/test_pdf_figure_identity.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import fitz
+
+from backend.parser.pdf_parser import PDFParser, _CAPTION_RE
+
+
+def test_parser_recognizes_chinese_figure_and_table_captions() -> None:
+    assert _CAPTION_RE.search("图 ５ 2000-2015 年度分布")
+    assert _CAPTION_RE.search("表 ２ 年度统计摘要")
+    assert PDFParser._normalize_caption_text("图 ５２０００ ２０１５ 年度分布") == "图 ５ ２０００ ２０１５ 年度分布"
+
+
+def test_parser_assigns_caption_above_table_region() -> None:
+    parser = PDFParser()
+    table = fitz.Rect(80, 180, 480, 420)
+    captions = {
+        "table": ("表 １ 卫星影像数据", fitz.Rect(160, 145, 360, 165)),
+        "figure": ("图 ２ 面积变化", fitz.Rect(160, 500, 360, 520)),
+    }
+
+    assert parser._nearest_caption(table, captions) == "表 １ 卫星影像数据"
+
+
+def test_parser_expands_sparse_long_figure_but_separates_stacked_figures() -> None:
+    parser = PDFParser()
+    page_rect = fitz.Rect(0, 0, 600, 800)
+    header = {"text": "Journal header", "rect": fitz.Rect(40, 60, 500, 84), "char_count": 14}
+    long_caption = fitz.Rect(100, 590, 350, 610)
+    expanded = parser._normalize_caption_clip(
+        fitz.Rect(70, 180, 500, 586),
+        page_rect,
+        long_caption,
+        [header],
+        {"long": ("图 ５ 年度频率分布", long_caption)},
+    )
+    assert expanded.y0 == 92
+    assert expanded.x0 == 24
+    assert expanded.x1 == 576
+
+    upper_caption = fitz.Rect(100, 200, 350, 218)
+    lower_caption = fitz.Rect(100, 450, 350, 468)
+    separated = parser._normalize_caption_clip(
+        fitz.Rect(70, 160, 500, 446),
+        page_rect,
+        lower_caption,
+        [header],
+        {
+            "upper": ("图 ２ 面积变化", upper_caption),
+            "lower": ("图 ３ 覆盖比例", lower_caption),
+        },
+    )
+    assert separated.y0 >= upper_caption.y1 + 10
+    assert separated.x0 == 24
+    assert separated.x1 == 576

--- a/tests/test_provider_memory.py
+++ b/tests/test_provider_memory.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.orchestrator.manuscript import normalize_manuscript_slide_delimiters
+from backend.orchestrator.provider_memory import build_provider_memory, build_slide_contexts
+from backend.parser.paper_model import ParsedPaper, PaperFigure, PaperSection
+
+
+def _paper(tmp_path: Path) -> ParsedPaper:
+    fig = PaperFigure(
+        path=tmp_path / "fig_001_p1.png",
+        caption="Figure 1: benchmark accuracy improves with sparse attention.",
+        natural_width=800,
+        natural_height=400,
+        quality_score=0.92,
+    )
+    return ParsedPaper(
+        title="Fast Long Context Models",
+        authors=["A. Researcher"],
+        abstract="We study long-context inference and reduce KV cache while improving benchmark accuracy.",
+        sections=[
+            PaperSection(
+                title="Method",
+                level=1,
+                content=(
+                    "The architecture combines sparse attention with cache compression. "
+                    "It reduces KV cache by 60% and lowers FLOPs by 35% on 128K-token inference. "
+                    "A routing module selects high-value tokens for exact attention."
+                ),
+                figures=[fig],
+            ),
+            PaperSection(
+                title="Experiments",
+                level=1,
+                content=(
+                    "On LongBench, the model reaches 74.2 accuracy compared with a 68.1 baseline. "
+                    "Ablation experiments show the routing module contributes 3.4 points."
+                ),
+            ),
+        ],
+    )
+
+
+def test_provider_memory_compacts_full_paper_and_keeps_evidence(tmp_path: Path) -> None:
+    memory = build_provider_memory(_paper(tmp_path))
+
+    assert "High-Value Evidence Cards" in memory.compact_markdown
+    assert len(memory.compact_markdown) < len(_paper(tmp_path).to_markdown()) + 2000
+    assert any("60%" in card.text for card in memory.evidence_cards)
+    assert memory.figures[0].id == "fig_001_p1"
+
+
+def test_slide_context_retrieves_relevant_cards(tmp_path: Path) -> None:
+    memory = build_provider_memory(_paper(tmp_path))
+    manuscript = normalize_manuscript_slide_delimiters(
+        """
+<!-- page_type: content -->
+## KV Cache Efficiency
+
+- Explain sparse attention and KV cache reduction.
+[[FIG:fig_001_p1]]
+        """
+    )
+
+    contexts = build_slide_contexts(manuscript, memory)
+
+    assert 1 in contexts
+    assert "Provider Slide Working Memory" in contexts[1]
+    assert "KV cache" in contexts[1] or "cache" in contexts[1]
+    assert "fig_001_p1" in contexts[1]

--- a/tests/test_provider_memory.py
+++ b/tests/test_provider_memory.py
@@ -11,6 +11,9 @@ def _paper(tmp_path: Path) -> ParsedPaper:
     fig = PaperFigure(
         path=tmp_path / "fig_001_p1.png",
         caption="Figure 1: benchmark accuracy improves with sparse attention.",
+        page_number=1,
+        bbox=(80.0, 120.0, 480.0, 320.0),
+        extraction_method="caption_region",
         natural_width=800,
         natural_height=400,
         quality_score=0.92,
@@ -49,6 +52,9 @@ def test_provider_memory_compacts_full_paper_and_keeps_evidence(tmp_path: Path) 
     assert len(memory.compact_markdown) < len(_paper(tmp_path).to_markdown()) + 2000
     assert any("60%" in card.text for card in memory.evidence_cards)
     assert memory.figures[0].id == "fig_001_p1"
+    assert memory.figures[0].bbox == (80.0, 120.0, 480.0, 320.0)
+    assert memory.figures[0].extraction_method == "caption_region"
+    assert "caption_region" in memory.compact_markdown
 
 
 def test_slide_context_retrieves_relevant_cards(tmp_path: Path) -> None:
@@ -69,3 +75,4 @@ def test_slide_context_retrieves_relevant_cards(tmp_path: Path) -> None:
     assert "Provider Slide Working Memory" in contexts[1]
     assert "KV cache" in contexts[1] or "cache" in contexts[1]
     assert "fig_001_p1" in contexts[1]
+    assert "source=caption_region" in contexts[1]

--- a/tests/test_svg_executor_figure_safety.py
+++ b/tests/test_svg_executor_figure_safety.py
@@ -1,0 +1,85 @@
+from backend.generator.svg_critic import CriticConfig
+from backend.orchestrator.svg_executor import (
+    _generation_static_report,
+    _optimize_figure_choices,
+    _validate_paper_figure_geometry,
+)
+
+
+def test_paper_figure_geometry_rejects_off_canvas_overcrop() -> None:
+    svg = """
+    <svg viewBox="0 0 1280 720">
+      <defs>
+        <clipPath id="leftPanelClip"><rect x="540" y="100" width="680" height="360"/></clipPath>
+      </defs>
+      <image href="../sources/images/fig_001_p1_vec.png" x="540" y="100"
+             width="1361" height="724" clip-path="url(#leftPanelClip)" />
+    </svg>
+    """
+    report = _validate_paper_figure_geometry(
+        svg,
+        allowed_figures=[
+            {
+                "path": "../sources/images/fig_001_p1_vec.png",
+                "natural_width": 1361,
+                "natural_height": 724,
+            }
+        ],
+    )
+
+    assert not report.passed
+    rules = {violation.rule for violation in report.violations}
+    assert "paper_figure_out_of_bounds" in rules
+    assert "paper_figure_overcropped" in rules
+
+
+def test_generation_static_report_runs_figure_safety_without_general_critic() -> None:
+    svg = """
+    <svg viewBox="0 0 1280 720">
+      <image href="../sources/images/fig_001_p1_vec.png" x="40" y="330"
+             width="1199" height="638" />
+    </svg>
+    """
+    report = _generation_static_report(
+        svg,
+        critic_config=CriticConfig(),
+        allowed_figures=[
+            {
+                "path": "../sources/images/fig_001_p1_vec.png",
+                "natural_width": 1361,
+                "natural_height": 724,
+            }
+        ],
+        used_paper_figures={},
+        required_icon=None,
+        include_general_svg_checks=False,
+    )
+
+    assert not report.passed
+    assert any(v.rule == "paper_figure_out_of_bounds" for v in report.violations)
+
+
+def test_optimize_figure_choices_prefers_slide_friendly_same_caption_table() -> None:
+    current = {
+        "path": "../sources/images/fig_038_p58_table.png",
+        "caption": "Table 14 | DeepSeek-V4-Pro vs. Claude-Opus-4.5",
+        "page_number": 58,
+        "natural_width": 1325,
+        "natural_height": 588,
+        "aspect_ratio": 2.25,
+        "quality_score": 0.92,
+    }
+    compact = {
+        "path": "../sources/images/fig_039_p58_table.png",
+        "caption": "Table 14 | DeepSeek-V4-Pro vs. Claude-Opus-4.5",
+        "page_number": 58,
+        "natural_width": 1108,
+        "natural_height": 240,
+        "aspect_ratio": 4.62,
+        "quality_score": 0.92,
+    }
+
+    optimized, notes = _optimize_figure_choices([current], [current, compact])
+
+    assert optimized[0]["path"].endswith("fig_039_p58_table.png")
+    assert notes

--- a/tests/test_worker_concurrency.py
+++ b/tests/test_worker_concurrency.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from backend.workers import consumer
+
+
+def test_configured_worker_count_is_clamped(monkeypatch) -> None:
+    monkeypatch.setattr(consumer.settings, "generation_worker_concurrency", 99)
+
+    assert consumer.worker_count() == 8
+
+
+def test_auto_worker_count_is_at_least_one(monkeypatch) -> None:
+    monkeypatch.setattr(consumer.settings, "generation_worker_concurrency", 0)
+    monkeypatch.setattr(consumer.os, "cpu_count", lambda: 2)
+
+    assert consumer.worker_count() == 1

--- a/uv.lock
+++ b/uv.lock
@@ -568,6 +568,15 @@ wheels = [
 ]
 
 [[package]]
+name = "huey"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/01/5f0fb711585af22412baee31a9a6a88975c33a58c57ec618e09be20bcc88/huey-3.0.1.tar.gz", hash = "sha256:83ca54fa77c4ee27349393212fc13088142244f491be903f620a9e46e8fca4ce", size = 253328, upload-time = "2026-05-14T15:35:02.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/37/1056e57ffb9d0fa1b859e02c9e5f7cf1e8276c8f5b610050e2a755f5c060/huey-3.0.1-py3-none-any.whl", hash = "sha256:5de8ff852021da670efe8d4d78db8719c0255ebbde0772766a0114f997ea61f6", size = 86331, upload-time = "2026-05-14T15:35:01.314Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -933,12 +942,15 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "google-genai" },
     { name = "httpx" },
+    { name = "huey" },
     { name = "jinja2" },
     { name = "lxml" },
     { name = "numpy" },
     { name = "openai" },
     { name = "openai-codex" },
+    { name = "peewee" },
     { name = "pillow" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pylatexenc" },
@@ -971,12 +983,15 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "huey", specifier = ">=3.0.1" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "numpy", specifier = ">=1.20.0" },
     { name = "openai", specifier = ">=1.50.0" },
     { name = "openai-codex", git = "https://github.com/openai/codex.git?subdirectory=sdk%2Fpython&rev=7d47056ea42636271ac020b86347fbbef49490aa" },
+    { name = "peewee", specifier = ">=4.0.6" },
     { name = "pillow", specifier = ">=9.0.0" },
+    { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pydantic-settings", specifier = ">=2.6.0" },
     { name = "pylatexenc", specifier = ">=2.10" },
@@ -996,6 +1011,15 @@ requires-dist = [
     { name = "websockets", specifier = ">=13.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "peewee"
+version = "4.0.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/09/a3b2a32ce498f405dce4320267e99b1b076c1ea39ad01151a353bc7f81d7/peewee-4.0.6.tar.gz", hash = "sha256:ea2f78f24ff9e3660281dc5b0be8bc00d9a9514bdc40c98e416fcd042b66ac6a", size = 724591, upload-time = "2026-05-20T13:18:17.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/6a/e1455b94ee48f5666f2e7831b6247098794bfe9747da457111be4d0bea10/peewee-4.0.6-py3-none-any.whl", hash = "sha256:5fa665913c410f0b5faef1469ed0aa9eceb9fef262665ebbb6f29408f826eeeb", size = 146222, upload-time = "2026-05-20T13:18:15.694Z" },
+]
 
 [[package]]
 name = "pillow"
@@ -1056,6 +1080,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
     { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
     { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Move provider-backed PPT generation out of the FastAPI worker into a SQLiteHuey queue plus isolated Python job subprocesses.
- Add durable per-job event logs and a monitor that replays worker progress back into the existing session/WebSocket state.
- Detect lost/zombie provider workers, make cancel transition immediately to a terminal state, and skip cancelled queued jobs reliably.
- Select provider worker concurrency dynamically with an environment override for local resource control.
- Extend LLM retry handling to socket disconnect/reset failures with a 10-attempt exponential-backoff budget.
- Fix the Agent-mode `_relative_path` failure path so missing output reports the real diagnostic.
- Add a one-window dev launcher used by `start-dev.bat` and `start-dev.sh`, including process-tree cleanup and color-preserving prefixed logs.
- Add provider working-memory compaction and generation-time figure safety checks for bounded context and safer image placement.

## Why

Provider generation could previously block the backend event loop or starve normal HTTP/WebSocket handling when PDF parsing, native libraries, or long LLM calls stalled. Isolated workers keep FastAPI responsive. Follow-up fixes ensure killed workers do not remain displayed as active jobs and transient network disconnects do not fail a long generation immediately.

## Validation

- `uv run python -m compileall backend`
- `$env:PYTHONPATH='.'; uv run --with pytest-asyncio pytest` (`39 passed`)
- `git diff --check`