### PR TITLE
Fix Agent result chat history restoration

### DIFF
--- a/backend/api/endpoints/status.py
+++ b/backend/api/endpoints/status.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Response, status
+from fastapi import APIRouter, HTTPException, Query, Response, status
 
 from backend.api.schemas import CancelJobResponse, JobStatus
 from backend.session.manager import session_manager
@@ -36,6 +36,25 @@ async def get_job_status(job_id: str) -> JobStatus:
         model=job.model_name,
         base_url=job.base_url,
     )
+
+
+@router.get("/status/{job_id}/events")
+async def get_job_events(job_id: str, since_seq: int = Query(default=0, ge=0)) -> dict:
+    """Return retained job events for deterministic result-page hydration."""
+    from backend.runtime.job_event_monitor import sync_job_events_once
+
+    await sync_job_events_once(job_id)
+    job = session_manager.get_job(job_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Job not found.",
+        )
+    return {
+        "job_id": job_id,
+        "last_seq": job.last_seq,
+        "events": session_manager.get_events_after(job_id, since_seq),
+    }
 
 
 @router.post("/status/{job_id}/cancel", response_model=CancelJobResponse)

--- a/frontend/src/hooks/useGeneration.ts
+++ b/frontend/src/hooks/useGeneration.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import { cancelJob, deleteJob, deleteSession, fetchBackendHealth, fetchJobStatus, fetchPreview, fetchProjectPreview, fetchProviders, generatePresentation, interruptGenerationAgent, isNotFoundError, refinePresentation, sendGenerationAgentFeedback, uploadPaper } from "../lib/api";
+import { cancelJob, deleteJob, deleteSession, fetchBackendHealth, fetchJobEvents, fetchJobStatus, fetchPreview, fetchProjectPreview, fetchProviders, generatePresentation, interruptGenerationAgent, isNotFoundError, refinePresentation, sendGenerationAgentFeedback, uploadPaper } from "../lib/api";
 import type {
   CriticEvent,
   GenerateRequestPayload,
@@ -131,6 +131,7 @@ interface GenerationState {
   interruptCurrentAgent: () => Promise<void>;
   sendAgentFeedback: (message: string, jobId?: string) => Promise<void>;
   connect: (jobId: string, options?: { replayFromStart?: boolean }) => void;
+  hydrateAgentHistory: (jobId: string, options?: { force?: boolean }) => Promise<void>;
   hydrateResult: (jobId: string) => Promise<void>;
   refreshHistoryStatuses: () => Promise<void>;
   resumeCurrentRun: (targetJobId?: string) => Promise<boolean>;
@@ -446,6 +447,14 @@ function isGenerationSubagentTool(tool: string | undefined): boolean {
   if (!tool) return false;
   const normalized = tool.toLowerCase();
   return normalized === "task" || normalized.endsWith(":task");
+}
+
+function hasHydratedAgentHistory(run?: RunSnapshot): boolean {
+  return Boolean(
+    run &&
+      typeof run.lastSeq === "number" &&
+      run.agentMessages.some((message) => message.role === "assistant" || message.role === "system"),
+  );
 }
 
 function applyRunToCurrent(run?: RunSnapshot) {
@@ -1284,6 +1293,49 @@ export const useGeneration = create<GenerationState>()(
             [jobId]: socket,
           },
         }));
+      },
+      async hydrateAgentHistory(jobId, options) {
+        const existingRun = get().runs[jobId];
+        if (!options?.force && hasHydratedAgentHistory(existingRun)) {
+          return;
+        }
+        const response = await fetchJobEvents(jobId, 0);
+        const nextMessagesById = new Map<string, GenerationAgentMessage>();
+        for (const message of existingRun?.agentMessages ?? []) {
+          nextMessagesById.set(message.id, message);
+        }
+        let lastSeq = Math.max(existingRun?.lastSeq ?? 0, response.last_seq ?? 0);
+        for (const event of response.events) {
+          const seq = typeof event.seq === "number" ? event.seq : undefined;
+          if (typeof seq === "number" && seq > lastSeq) {
+            lastSeq = seq;
+          }
+          const message = agentMessageFromEvent(event);
+          if (message) {
+            nextMessagesById.set(message.id, message);
+          }
+        }
+        const agentMessages = Array.from(nextMessagesById.values())
+          .sort((left, right) => left.created_at - right.created_at)
+          .slice(-PERSISTED_LOG_LIMIT);
+        if (lastSeq > 0) {
+          seenSeqByJob.set(jobId, lastSeq);
+        }
+        set((state) => {
+          const currentRun = state.runs[jobId] ?? createRunSnapshot(jobId);
+          const updatedRun: RunSnapshot = {
+            ...currentRun,
+            agentMessages,
+            lastSeq: lastSeq || currentRun.lastSeq,
+          };
+          return {
+            ...(state.jobId === jobId ? applyRunToCurrent(updatedRun) : {}),
+            runs: {
+              ...state.runs,
+              [jobId]: updatedRun,
+            },
+          };
+        });
       },
       async hydrateResult(jobId) {
         const historyEntry = get().history.find((entry) => entry.jobId === jobId);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   ImportStartResponse,
   ImportStatus,
   JobStatus,
+  JobEventsResponse,
   PreviewResponse,
   PreviewSlide,
   PptistDeckPayload,
@@ -154,6 +155,10 @@ export async function fetchProviders(): Promise<ProvidersResponse> {
 
 export async function fetchBackendHealth(init?: RequestInit): Promise<HealthResponse> {
   return request<HealthResponse>("/healthz", init);
+}
+
+export async function fetchJobEvents(jobId: string, sinceSeq = 0): Promise<JobEventsResponse> {
+  return request<JobEventsResponse>(`/api/status/${jobId}/events?since_seq=${Math.max(0, sinceSeq)}`);
 }
 
 export async function fetchTemplates(): Promise<TemplateInfo[]> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -752,6 +752,12 @@ export interface JobPingEvent {
 
 export type JobSocketMessage = JobEvent | JobPingEvent;
 
+export interface JobEventsResponse {
+  job_id: string;
+  last_seq: number;
+  events: JobEvent[];
+}
+
 export interface RefineRequestPayload {
   job_id: string;
   feedback: string;

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -67,6 +67,7 @@ export function ResultPage() {
     cancelCurrentRun,
     interruptCurrentAgent,
     connect,
+    hydrateAgentHistory,
     activeJobId,
     job: liveJob,
     slides: liveSlides,
@@ -180,12 +181,17 @@ export function ResultPage() {
       return;
     }
     const run = useGeneration.getState().runs[jobId];
-    if ((run?.agentMessages.length ?? 0) > 0 && typeof run?.lastSeq === "number") {
+    if (run && typeof run.lastSeq === "number" && run.agentMessages.some((message) => message.role !== "user")) {
       return;
     }
     requestedAgentHistoryForJob.current = jobId;
-    connect(jobId, { replayFromStart: (run?.agentMessages.length ?? 0) === 0 });
-  }, [connect, isAgentResult, jobId, resultRunStatus]);
+    void hydrateAgentHistory(jobId).catch(() => {
+      const latestRun = useGeneration.getState().runs[jobId];
+      if ((latestRun?.agentMessages.length ?? 0) === 0) {
+        connect(jobId, { replayFromStart: true });
+      }
+    });
+  }, [connect, hydrateAgentHistory, isAgentResult, jobId, resultRunStatus]);
 
   useEffect(() => {
     let cancelled = false;

--- a/tests/test_agent_history_events.py
+++ b/tests/test_agent_history_events.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from backend.api.endpoints import status
+from backend.runtime import job_event_monitor
+
+
+class _EventsManager:
+    def __init__(self) -> None:
+        self.job = SimpleNamespace(last_seq=3)
+        self.events = [
+            {"seq": 1, "stage": "agent", "message": "first"},
+            {"seq": 2, "stage": "agent", "message": "second"},
+            {"seq": 3, "stage": "export", "message": "done"},
+        ]
+
+    def get_job(self, job_id: str):
+        return self.job if job_id == "job-1" else None
+
+    def get_events_after(self, _job_id: str, since_seq: int) -> list[dict]:
+        return [event for event in self.events if int(event["seq"]) > since_seq]
+
+
+@pytest.mark.asyncio
+async def test_job_events_endpoint_returns_retained_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _noop_sync(_job_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(status, "session_manager", _EventsManager())
+    monkeypatch.setattr(job_event_monitor, "sync_job_events_once", _noop_sync)
+
+    payload = await status.get_job_events("job-1", since_seq=1)
+
+    assert payload["job_id"] == "job-1"
+    assert payload["last_seq"] == 3
+    assert [event["seq"] for event in payload["events"]] == [2, 3]


### PR DESCRIPTION
## Summary
- add a retained job-events REST endpoint for deterministic Agent history hydration
- restore Agent result-page messages from retained events when opening a completed task
- keep WebSocket replay as fallback instead of relying on sending feedback to trigger history replay

## Validation
- npm run build
- uv run --extra dev python -m pytest -q (47 passed)

This PR follows #48 and contains the result-page chat history fix only.