### PR TITLE
Fix PPTist dev backend port routing

### DIFF
--- a/backend/dev_launcher.py
+++ b/backend/dev_launcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -18,7 +19,13 @@ def _npm_cmd() -> str:
     return "npm.cmd" if sys.platform.startswith("win") else "npm"
 
 
-def _spawn(name: str, argv: list[str], cwd: Path) -> subprocess.Popen[str]:
+def _spawn(
+    name: str,
+    argv: list[str],
+    cwd: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.Popen[str]:
     env = dict(os.environ)
     env["PYTHONUNBUFFERED"] = "1"
     env["PYTHONIOENCODING"] = "utf-8"
@@ -27,6 +34,8 @@ def _spawn(name: str, argv: list[str], cwd: Path) -> subprocess.Popen[str]:
     env["COLORTERM"] = env.get("COLORTERM", "truecolor")
     env["TERM"] = env.get("TERM", "xterm-256color")
     env["npm_config_color"] = "always"
+    if extra_env:
+        env.update(extra_env)
     proc = subprocess.Popen(
         argv,
         cwd=str(cwd),
@@ -42,6 +51,29 @@ def _spawn(name: str, argv: list[str], cwd: Path) -> subprocess.Popen[str]:
     thread = threading.Thread(target=_pipe_output, args=(name, proc), daemon=True)
     thread.start()
     return proc
+
+
+def _port_available(host: str, port: int) -> bool:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((host, port))
+    except OSError:
+        return False
+    return True
+
+
+def _choose_backend_port(host: str, requested: int) -> int:
+    if _port_available(host, requested):
+        return requested
+
+    for candidate in [*range(8200, 8300), *range(8001, 8100)]:
+        if _port_available(host, candidate):
+            return candidate
+
+    raise RuntimeError(
+        f"No available backend port found for {host}; tried {requested}, 8200-8299, 8001-8099."
+    )
 
 
 def _pipe_output(name: str, proc: subprocess.Popen[str]) -> None:
@@ -96,18 +128,22 @@ def _kill(proc: subprocess.Popen[str]) -> None:
 
 def main() -> int:
     processes: list[subprocess.Popen[str]] = []
+    backend_host = os.environ.get("BACKEND_HOST", "127.0.0.1")
+    requested_backend_port = int(os.environ.get("BACKEND_PORT", "8000"))
+    backend_port = _choose_backend_port(backend_host, requested_backend_port)
+    backend_base_url = f"http://{backend_host}:{backend_port}"
     commands = [
         (
-            "backend",
+            f"backend:{backend_port}",
             [
                 sys.executable,
                 "-m",
                 "uvicorn",
                 "backend.app:app",
                 "--host",
-                "127.0.0.1",
+                backend_host,
                 "--port",
-                "8000",
+                str(backend_port),
                 "--reload",
                 "--reload-dir",
                 "backend",
@@ -136,6 +172,7 @@ def main() -> int:
                 "--open",
             ],
             FRONTEND_DIR,
+            {"VITE_API_BASE": backend_base_url},
         ),
     ]
 
@@ -152,13 +189,20 @@ def main() -> int:
         signal.signal(signal.SIGTERM, _request_stop)
 
     try:
-        for name, argv, cwd in commands:
+        for command in commands:
+            name, argv, cwd = command[:3]
+            extra_env = command[3] if len(command) > 3 else None
             print(f"==> Starting {name}", flush=True)
-            processes.append(_spawn(name, argv, cwd))
+            processes.append(_spawn(name, argv, cwd, extra_env=extra_env))
 
         print("", flush=True)
+        if backend_port != requested_backend_port:
+            print(
+                f"Requested backend port {requested_backend_port} is unavailable; using {backend_port}.",
+                flush=True,
+            )
         print("Paper PPT Agent is starting:", flush=True)
-        print("  Backend:  http://127.0.0.1:8000", flush=True)
+        print(f"  Backend:  {backend_base_url}", flush=True)
         print("  Frontend: http://127.0.0.1:5173", flush=True)
         print("  Worker:   SQLiteHuey local queue (dynamic concurrency)", flush=True)
         print("Press Ctrl+C to stop all processes.", flush=True)

--- a/frontend/src/pptist/PaperApp.vue
+++ b/frontend/src/pptist/PaperApp.vue
@@ -95,21 +95,27 @@ const appRootRef = ref<HTMLElement | null>(null)
 let stopDomI18n: (() => void) | undefined
 const statusBusy = computed(() => statusKind.value === 'busy' && !!statusText.value && !errorText.value)
 const statusSaved = computed(() => statusKind.value === 'success' && !!statusText.value && !errorText.value)
+const apiBase = String(import.meta.env.VITE_API_BASE || '').replace(/\/$/, '')
+
+const apiUrl = (path: string) => {
+  if (!apiBase || /^(https?:|data:|blob:)/i.test(path)) return path
+  return path.startsWith('/') ? `${apiBase}${path}` : `${apiBase}/${path}`
+}
 
 const deckEndpoint = computed(() => {
-  if (props.options.kind === 'templateImport') return `/api/templates/import/${props.options.id}/pptist/deck`
-  return `/api/pptist/preview/${props.options.id}/deck`
+  if (props.options.kind === 'templateImport') return apiUrl(`/api/templates/import/${props.options.id}/pptist/deck`)
+  return apiUrl(`/api/pptist/preview/${props.options.id}/deck`)
 })
 
 const exportEndpoint = computed(() => {
-  if (props.options.kind === 'templateImport') return `/api/templates/import/${props.options.id}/pptist/export`
-  return `/api/pptist/preview/${props.options.id}/export`
+  if (props.options.kind === 'templateImport') return apiUrl(`/api/templates/import/${props.options.id}/pptist/export`)
+  return apiUrl(`/api/pptist/preview/${props.options.id}/export`)
 })
 
 const paperDownloadUrl = computed(() => {
   if (props.options.downloadUrl) return props.options.downloadUrl
   if (props.options.kind !== 'preview') return ''
-  return `/api/download/${props.options.id}`
+  return apiUrl(`/api/download/${props.options.id}`)
 })
 
 const setStatus = (message: string, kind: 'busy' | 'success' | 'info' = 'busy') => {
@@ -171,7 +177,7 @@ const loadDeck = async () => {
 
 const importSourcePptx = async (sourceUrl: string) => {
   setStatus(pptistT('pptist.parsingPptx'))
-  const response = await fetch(sourceUrl)
+  const response = await fetch(apiUrl(sourceUrl))
   if (!response.ok) throw new Error(await response.text())
   const blob = await response.blob()
   const file = new File([blob], 'source.pptx', {


### PR DESCRIPTION
## Summary
- choose an available backend port in the one-window dev launcher and pass it to the frontend via VITE_API_BASE
- route PPTist deck/export/download/source PPTX requests through VITE_API_BASE so dynamic backend ports work

## Verification
- npm run build
- uv run python -m py_compile backend\\dev_launcher.py