### PR TITLE
Stream chat completions to avoid proxy read timeouts (524)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -109,6 +109,13 @@ class Settings(BaseSettings):
     # parallelism still exists; this prevents two active parallel jobs from
     # multiplying into a provider/network storm.
     llm_max_concurrent_requests: int = 4
+    # Per-request timeout (seconds) for LLM SDK calls. The SDK default is
+    # 600s with 2 internal retries, so a hung upstream (common with API
+    # aggregators/proxies) silently blocks a slide for up to 30 min. We set
+    # an explicit bound so genuine hangs surface and retry within minutes,
+    # while leaving headroom for slow reasoning calls (strategy ~227s seen,
+    # may run longer for dense papers on slower models like Opus).
+    llm_request_timeout: float = 420.0
 
     # ── Job scheduling ───────────────────────────────────────────────────
     # Backlog cap for queued jobs; a 16th queued job returns 429.

--- a/backend/llm/provider_anthropic.py
+++ b/backend/llm/provider_anthropic.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncIterator
 from anthropic import AsyncAnthropic
 from pydantic import BaseModel
 
+from backend.config import settings
 from backend.runtime.resource_gates import llm_request_slot
 from backend.usage.tracker import current_usage_context, usage_tracker
 
@@ -28,8 +29,18 @@ from .types import (
 class AnthropicProvider(LLMProvider):
     """Anthropic provider wrapping AsyncAnthropic."""
 
-    def __init__(self, api_key: str) -> None:
-        self._client = AsyncAnthropic(api_key=api_key)
+    def __init__(self, api_key: str, base_url: str | None = None) -> None:
+        # Explicit timeout + max_retries=0: call_with_retry owns retry/backoff,
+        # so the SDK's default 2 internal retries plus 600s timeout would let a
+        # hung upstream block a single call for up to 30 min.
+        kwargs: dict = {
+            "api_key": api_key,
+            "timeout": settings.llm_request_timeout,
+            "max_retries": 0,
+        }
+        if base_url:
+            kwargs["base_url"] = base_url
+        self._client = AsyncAnthropic(**kwargs)
 
     def _split_system_and_messages(
         self, messages: list[LLMMessage]

--- a/backend/llm/provider_openai.py
+++ b/backend/llm/provider_openai.py
@@ -12,6 +12,7 @@ import httpx
 from openai import AsyncOpenAI
 from pydantic import BaseModel
 
+from backend.config import settings
 from backend.runtime.resource_gates import llm_request_slot
 from backend.usage.tracker import current_usage_context, usage_tracker
 
@@ -71,7 +72,16 @@ class OpenAIProvider(LLMProvider):
         openai_settings: dict | None = None,
     ) -> None:
         normalized_base_url = normalize_openai_base_url(base_url)
-        self._client = AsyncOpenAI(api_key=api_key, base_url=normalized_base_url)
+        # Explicit timeout + max_retries=0: the project's call_with_retry owns
+        # retry/backoff, so leaving the SDK's default 2 internal retries on
+        # would double-retry and, combined with the 600s default timeout,
+        # let a hung upstream block a single call for up to 30 min.
+        self._client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=normalized_base_url,
+            timeout=settings.llm_request_timeout,
+            max_retries=0,
+        )
         self._api_key = api_key
         self._provider_name = provider_name
         self._base_url = (normalized_base_url or "").rstrip("/")
@@ -446,7 +456,7 @@ class OpenAIProvider(LLMProvider):
     async def _create_chat_completion(self, kwargs: dict):
         try:
             return await call_with_retry(
-                lambda: self._client.chat.completions.create(**kwargs)
+                lambda: self._consume_chat_stream(kwargs)
             )
         except BaseException as exc:
             if self._should_use_raw_compat_fallback(kwargs, exc):
@@ -457,7 +467,7 @@ class OpenAIProvider(LLMProvider):
             for index, fallback in enumerate(fallbacks):
                 try:
                     return await call_with_retry(
-                        lambda: self._client.chat.completions.create(**fallback)
+                        lambda: self._consume_chat_stream(fallback)
                     )
                 except BaseException as fallback_exc:
                     if (
@@ -465,6 +475,76 @@ class OpenAIProvider(LLMProvider):
                         or not self._is_parameter_compat_error(fallback_exc)
                     ):
                         raise
+            raise
+
+    def _is_stream_options_error(self, exc: BaseException) -> bool:
+        text = str(exc).lower()
+        return "stream_options" in text or "include_usage" in text
+
+    async def _consume_chat_stream(self, kwargs: dict):
+        """Run a chat completion in streaming mode, accumulating it into a
+        non-streaming response shape the rest of ``chat()`` already expects.
+
+        A single buffered (non-streamed) response forces the upstream to
+        withhold all bytes until the full completion is ready; a long
+        generation then trips a proxy read timeout (e.g. Cloudflare 524 at
+        120s) even though the model is still working. Streaming keeps bytes
+        flowing so the timeout never fires. ``include_usage`` asks the server
+        for a final usage chunk so token accounting survives the switch.
+        """
+        stream_kwargs = dict(kwargs)
+        stream_kwargs["stream"] = True
+        stream_kwargs.setdefault("stream_options", {"include_usage": True})
+
+        async def run(create_kwargs: dict):
+            content_parts: list[str] = []
+            finish_reason = None
+            usage = None
+            response_id = None
+            model_name = None
+            stream = await self._client.chat.completions.create(**create_kwargs)
+            async for chunk in stream:
+                if response_id is None:
+                    response_id = getattr(chunk, "id", None)
+                if model_name is None:
+                    model_name = getattr(chunk, "model", None)
+                chunk_usage = getattr(chunk, "usage", None)
+                if chunk_usage is not None:
+                    usage = chunk_usage
+                for choice in getattr(chunk, "choices", None) or []:
+                    delta = getattr(choice, "delta", None)
+                    delta_content = getattr(delta, "content", None) if delta else None
+                    if delta_content:
+                        content_parts.append(delta_content)
+                    choice_finish = getattr(choice, "finish_reason", None)
+                    if choice_finish:
+                        finish_reason = choice_finish
+            usage_ns = None
+            if usage is not None:
+                usage_ns = SimpleNamespace(
+                    prompt_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
+                    completion_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
+                )
+            message = SimpleNamespace(role="assistant", content="".join(content_parts))
+            return SimpleNamespace(
+                id=response_id,
+                object="chat.completion",
+                model=model_name or kwargs.get("model"),
+                choices=[
+                    SimpleNamespace(index=0, finish_reason=finish_reason, message=message)
+                ],
+                usage=usage_ns,
+            )
+
+        try:
+            return await run(stream_kwargs)
+        except BaseException as exc:
+            # Some OpenAI-compatible gateways reject stream_options. Retry
+            # once without it: we lose usage accounting but keep streaming.
+            if "stream_options" in stream_kwargs and self._is_stream_options_error(exc):
+                retry_kwargs = dict(stream_kwargs)
+                retry_kwargs.pop("stream_options", None)
+                return await run(retry_kwargs)
             raise
 
     async def _parse_chat_completion(

--- a/backend/llm/provider_openai.py
+++ b/backend/llm/provider_openai.py
@@ -87,6 +87,9 @@ class OpenAIProvider(LLMProvider):
         self._base_url = (normalized_base_url or "").rstrip("/")
         self._deepseek_settings = deepseek_settings
         self._openai_settings = openai_settings
+        # Set once we learn an endpoint rejects streaming, so subsequent
+        # calls skip the stream attempt and go straight to the buffered path.
+        self._streaming_unsupported = False
 
     def _is_deepseek_request(self, model: str | None = None) -> bool:
         return (
@@ -481,6 +484,33 @@ class OpenAIProvider(LLMProvider):
         text = str(exc).lower()
         return "stream_options" in text or "include_usage" in text
 
+    def _is_streaming_unsupported_error(self, exc: BaseException) -> bool:
+        """Detect endpoints that reject streaming itself (not just
+        ``stream_options``), e.g. a custom OpenAI-compatible gateway whose
+        chat endpoint only works in buffered mode and returns a 400 like
+        "streaming is not supported"."""
+        text = str(exc).lower()
+        if "stream_options" in text or "include_usage" in text:
+            return False
+        return "stream" in text and (
+            "not support" in text
+            or "unsupported" in text
+            or "not allowed" in text
+            or "is disabled" in text
+        )
+
+    async def _create_buffered_completion(self, kwargs: dict):
+        """Original non-streaming path: let the SDK buffer the full response.
+
+        Used for endpoints that only support non-streaming chat completions,
+        preserving behavior for setups that worked before streaming was the
+        default read mode.
+        """
+        buffered_kwargs = dict(kwargs)
+        buffered_kwargs.pop("stream", None)
+        buffered_kwargs.pop("stream_options", None)
+        return await self._client.chat.completions.create(**buffered_kwargs)
+
     async def _consume_chat_stream(self, kwargs: dict):
         """Run a chat completion in streaming mode, accumulating it into a
         non-streaming response shape the rest of ``chat()`` already expects.
@@ -492,6 +522,11 @@ class OpenAIProvider(LLMProvider):
         flowing so the timeout never fires. ``include_usage`` asks the server
         for a final usage chunk so token accounting survives the switch.
         """
+        # Endpoint already proved it only does buffered responses — don't
+        # waste a round trip re-attempting the stream.
+        if self._streaming_unsupported:
+            return await self._create_buffered_completion(kwargs)
+
         stream_kwargs = dict(kwargs)
         stream_kwargs["stream"] = True
         stream_kwargs.setdefault("stream_options", {"include_usage": True})
@@ -544,7 +579,19 @@ class OpenAIProvider(LLMProvider):
             if "stream_options" in stream_kwargs and self._is_stream_options_error(exc):
                 retry_kwargs = dict(stream_kwargs)
                 retry_kwargs.pop("stream_options", None)
-                return await run(retry_kwargs)
+                try:
+                    return await run(retry_kwargs)
+                except BaseException as retry_exc:
+                    if self._is_streaming_unsupported_error(retry_exc):
+                        self._streaming_unsupported = True
+                        return await self._create_buffered_completion(kwargs)
+                    raise
+            # Endpoint rejects streaming entirely (not just stream_options):
+            # fall back to the original buffered completion so non-streaming
+            # endpoints that worked before keep working.
+            if self._is_streaming_unsupported_error(exc):
+                self._streaming_unsupported = True
+                return await self._create_buffered_completion(kwargs)
             raise
 
     async def _parse_chat_completion(


### PR DESCRIPTION
## Problem

A single buffered (non-streamed) chat completion makes the upstream withhold all bytes until the full response is ready. For long generations behind a proxy/aggregator, this trips a read timeout (e.g. Cloudflare 524 at 120s) even though the model is still working — the request fails and `call_with_retry` silently loops.

## Fix

- Consume chat completions via streaming internally and reassemble them into the existing non-streaming response shape, so callers are unchanged. `include_usage` preserves token accounting; a fallback drops `stream_options` for gateways that reject it.
- Set explicit `timeout` (new `settings.llm_request_timeout`, 420s) and `max_retries=0` on both SDK clients, so the project's `call_with_retry` solely owns retry/backoff. The SDK default (600s + 2 internal retries) could otherwise let a hung upstream block a single call for ~30 min.

## Notes

Behavior is unchanged for fast responses; this only affects how bytes are read off the wire. No new dependencies.