### PR TITLE
Fix structured streaming and import guide dismissal

### DIFF
--- a/backend/llm/provider_openai.py
+++ b/backend/llm/provider_openai.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import httpx
 from openai import AsyncOpenAI
+from openai.lib._parsing import type_to_response_format_param
 from pydantic import BaseModel
 
 from backend.config import settings
@@ -511,6 +512,27 @@ class OpenAIProvider(LLMProvider):
         buffered_kwargs.pop("stream_options", None)
         return await self._client.chat.completions.create(**buffered_kwargs)
 
+    def _chat_kwargs_with_response_format(
+        self,
+        kwargs: dict,
+        response_format: type[BaseModel],
+    ) -> dict:
+        structured_kwargs = dict(kwargs)
+        structured_kwargs["response_format"] = type_to_response_format_param(
+            response_format
+        )
+        return structured_kwargs
+
+    def _attach_parsed_response_format(
+        self,
+        resp,
+        response_format: type[BaseModel],
+    ):
+        content = resp.choices[0].message.content or ""
+        parsed = response_format.model_validate_json(content)
+        resp.choices[0].message.parsed = parsed
+        return resp
+
     async def _consume_chat_stream(self, kwargs: dict):
         """Run a chat completion in streaming mode, accumulating it into a
         non-streaming response shape the rest of ``chat()`` already expects.
@@ -599,12 +621,40 @@ class OpenAIProvider(LLMProvider):
         kwargs: dict,
         response_format: type[BaseModel],
     ):
+        structured_kwargs = self._chat_kwargs_with_response_format(
+            kwargs,
+            response_format,
+        )
+        try:
+            resp = await call_with_retry(
+                lambda: self._consume_chat_stream(structured_kwargs)
+            )
+            return self._attach_parsed_response_format(resp, response_format)
+        except BaseException as exc:
+            if self._should_use_raw_compat_fallback(structured_kwargs, exc):
+                resp = await self._create_raw_chat_completion(structured_kwargs)
+                return self._attach_parsed_response_format(resp, response_format)
+            fallbacks = self._fallback_chat_kwargs(structured_kwargs)
+            if not fallbacks or not self._is_parameter_compat_error(exc):
+                raise
+            for index, fallback in enumerate(fallbacks):
+                try:
+                    resp = await call_with_retry(
+                        lambda: self._consume_chat_stream(fallback)
+                    )
+                    return self._attach_parsed_response_format(resp, response_format)
+                except BaseException as fallback_exc:
+                    if (
+                        index >= len(fallbacks) - 1
+                        or not self._is_parameter_compat_error(fallback_exc)
+                    ):
+                        raise
+            raise
+
+    async def _create_stream(self, kwargs: dict):
         try:
             return await call_with_retry(
-                lambda: self._client.beta.chat.completions.parse(
-                    **kwargs,
-                    response_format=response_format,
-                )
+                lambda: self._client.chat.completions.create(**kwargs)
             )
         except BaseException as exc:
             fallbacks = self._fallback_chat_kwargs(kwargs)
@@ -613,10 +663,7 @@ class OpenAIProvider(LLMProvider):
             for index, fallback in enumerate(fallbacks):
                 try:
                     return await call_with_retry(
-                        lambda: self._client.beta.chat.completions.parse(
-                            **fallback,
-                            response_format=response_format,
-                        )
+                        lambda: self._client.chat.completions.create(**fallback)
                     )
                 except BaseException as fallback_exc:
                     if (
@@ -734,24 +781,7 @@ class OpenAIProvider(LLMProvider):
         )
 
         async with llm_request_slot():
-            stream = None
-            try:
-                stream = await self._client.chat.completions.create(**kwargs)
-            except BaseException as exc:
-                fallbacks = self._fallback_chat_kwargs(kwargs)
-                if not fallbacks or not self._is_parameter_compat_error(exc):
-                    raise
-                for index, fallback in enumerate(fallbacks):
-                    try:
-                        stream = await self._client.chat.completions.create(**fallback)
-                        break
-                    except BaseException as fallback_exc:
-                        if (
-                            index >= len(fallbacks) - 1
-                            or not self._is_parameter_compat_error(fallback_exc)
-                        ):
-                            raise
-            assert stream is not None
+            stream = await self._create_stream(kwargs)
             async for chunk in stream:
                 delta = chunk.choices[0].delta
                 if delta.content:

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -1535,6 +1535,13 @@ function UploadCard({
     setSkipGuideNextTime(false);
   }, [mode]);
 
+  useEffect(() => {
+    if (!uploading) return;
+    setGuideMode(null);
+    setPendingFile(null);
+    setSkipGuideNextTime(false);
+  }, [uploading]);
+
   const requestFileSelection = () => {
     if (dismissedGuides[mode]) {
       inputRef.current?.click();
@@ -1554,10 +1561,14 @@ function UploadCard({
     if (pendingFile) {
       const file = pendingFile;
       setPendingFile(null);
-      void handleFile(file);
+      window.setTimeout(() => {
+        void handleFile(file);
+      }, 0);
       return;
     }
-    inputRef.current?.click();
+    window.setTimeout(() => {
+      inputRef.current?.click();
+    }, 0);
   };
 
   const onDragOver = (event: DragEvent<HTMLDivElement>) => {

--- a/tests/test_openai_provider_streaming.py
+++ b/tests/test_openai_provider_streaming.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from backend.llm.provider_openai import OpenAIProvider
+from backend.llm.types import LLMMessage
+
+
+class _StructuredResult(BaseModel):
+    name: str
+
+
+class _RetryableError(RuntimeError):
+    status_code = 500
+
+
+class _AsyncStream:
+    def __init__(self, chunks: list[SimpleNamespace]) -> None:
+        self._chunks = chunks
+
+    def __aiter__(self):
+        self._iter = iter(self._chunks)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _FakeCompletions:
+    def __init__(self, outcomes: list[object]) -> None:
+        self.outcomes = outcomes
+        self.calls: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+def _provider(completions: _FakeCompletions) -> OpenAIProvider:
+    provider = object.__new__(OpenAIProvider)
+    provider._client = SimpleNamespace(
+        chat=SimpleNamespace(completions=completions)
+    )
+    provider._api_key = "test"
+    provider._provider_name = "openai"
+    provider._base_url = ""
+    provider._deepseek_settings = None
+    provider._openai_settings = None
+    provider._streaming_unsupported = False
+    return provider
+
+
+def _chunk(
+    content: str | None = None,
+    *,
+    usage: SimpleNamespace | None = None,
+    finish_reason: str | None = None,
+) -> SimpleNamespace:
+    choices = []
+    if content is not None or finish_reason is not None:
+        choices.append(
+            SimpleNamespace(
+                delta=SimpleNamespace(content=content),
+                finish_reason=finish_reason,
+            )
+        )
+    return SimpleNamespace(
+        id="resp_1",
+        model="gpt-test",
+        usage=usage,
+        choices=choices,
+    )
+
+
+@pytest.mark.asyncio
+async def test_response_format_uses_streaming_and_attaches_parsed() -> None:
+    stream = _AsyncStream([
+        _chunk('{"name":'),
+        _chunk('"deck"}', finish_reason="stop"),
+        _chunk(
+            usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7),
+        ),
+    ])
+    completions = _FakeCompletions([stream])
+    provider = _provider(completions)
+
+    response = await provider.chat(
+        [LLMMessage.user("return json")],
+        "gpt-test",
+        response_format=_StructuredResult,
+    )
+
+    assert response.content == '{"name":"deck"}'
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == 11
+    assert response.usage.completion_tokens == 7
+    assert response.raw.choices[0].message.parsed == _StructuredResult(name="deck")
+    assert completions.calls[0]["stream"] is True
+    assert completions.calls[0]["stream_options"] == {"include_usage": True}
+    assert isinstance(completions.calls[0]["response_format"], dict)
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_creation_uses_shared_retry() -> None:
+    stream = _AsyncStream([
+        _chunk("hello", finish_reason="stop"),
+    ])
+    completions = _FakeCompletions([
+        _RetryableError("upstream unavailable"),
+        stream,
+    ])
+    provider = _provider(completions)
+
+    chunks = [
+        chunk
+        async for chunk in provider.chat_stream(
+            [LLMMessage.user("hi")],
+            "gpt-test",
+        )
+    ]
+
+    assert [chunk.delta for chunk in chunks] == ["hello"]
+    assert len(completions.calls) == 2


### PR DESCRIPTION
## Summary

- Stream OpenAI structured chat completions internally, then validate the streamed JSON locally and preserve `raw.choices[0].message.parsed` for existing callers.
- Route explicit `chat_stream()` creation through the shared retry helper now that SDK retries are disabled.
- Dismiss the direct/agent upload guide before opening the file picker or starting upload work so the modal does not remain stuck over an active import.
- Add provider tests covering structured streaming and stream creation retry.

## Root Cause

PR #56 moved ordinary OpenAI chat calls to streaming, but `response_format` still used the buffered parse endpoint. Also, the upload guide opened the browser file picker in the same tick as closing the modal, so the picker could block React from rendering the close before import work began.

## Validation

- `npm run build`
- `uv run python -m pytest tests/test_openai_provider_streaming.py tests/test_llm_retry.py`
- Opened `http://127.0.0.1:5173/templates` in the in-app browser and confirmed the templates page renders.
