### PR TITLE
Merge dev into master

### DIFF
--- a/backend/api/endpoints/generate.py
+++ b/backend/api/endpoints/generate.py
@@ -18,6 +18,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, status
 
 from backend.api.schemas import AgentFeedbackRequest, AgentFeedbackResponse, GenerateRequest, GenerateResponse
+from backend.runtime.job_timeout import run_with_optional_job_timeout
 from backend.runtime.scheduler import QueueFull, SchedulerDraining, get_scheduler
 from backend.session.manager import session_manager
 from backend.session.progress import describe_exception, payloads_from_progress_event
@@ -93,19 +94,16 @@ async def _run_generation_job(job_id: str, request: Any) -> None:
     timeout = getattr(request, "timeout_seconds", None)
     cleanup_needed = False
     try:
-        if timeout and timeout > 0:
-            await asyncio.wait_for(_iterate_pipeline(job_id, request), timeout=timeout)
-        else:
-            await _iterate_pipeline(job_id, request)
-    except asyncio.TimeoutError:
-        current_job = session_manager.get_job(job_id)
-        if current_job is None:
-            return
-        msg = f"Job exceeded timeout of {timeout}s"
-        error_event = ProgressEvent("error", "error", msg, current_job.progress)
-        for payload, updates in payloads_from_progress_event(job_id, current_job, error_event):
-            session_manager.record_event(job_id, payload, **updates)
-        cleanup_needed = True
+        timed_out = await run_with_optional_job_timeout(_iterate_pipeline(job_id, request), timeout)
+        if timed_out:
+            current_job = session_manager.get_job(job_id)
+            if current_job is None:
+                return
+            msg = f"Job exceeded timeout of {timeout}s"
+            error_event = ProgressEvent("error", "error", msg, current_job.progress)
+            for payload, updates in payloads_from_progress_event(job_id, current_job, error_event):
+                session_manager.record_event(job_id, payload, **updates)
+            cleanup_needed = True
     except asyncio.CancelledError:
         session_manager.mark_job_cancelled(job_id)
         cleanup_needed = True

--- a/backend/api/endpoints/refine.py
+++ b/backend/api/endpoints/refine.py
@@ -9,6 +9,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, status
 
 from backend.api.schemas import RefineRequest, RefineResponse
+from backend.runtime.job_timeout import run_with_optional_job_timeout
 from backend.runtime.scheduler import QueueFull, SchedulerDraining, get_scheduler
 from backend.session.manager import session_manager
 from backend.session.progress import describe_exception, payloads_from_progress_event
@@ -53,19 +54,16 @@ async def _run_refine_job(job_id: str, request: Any) -> None:
     timeout = getattr(request, "timeout_seconds", None)
     cleanup_needed = False
     try:
-        if timeout and timeout > 0:
-            await asyncio.wait_for(_iterate_refine_pipeline(job_id, request), timeout=timeout)
-        else:
-            await _iterate_refine_pipeline(job_id, request)
-    except asyncio.TimeoutError:
-        current_job = session_manager.get_job(job_id)
-        if current_job is None:
-            return
-        msg = f"Refine job exceeded timeout of {timeout}s"
-        error_event = ProgressEvent("error", "error", msg, current_job.progress)
-        for payload, updates in payloads_from_progress_event(job_id, current_job, error_event):
-            session_manager.record_event(job_id, payload, **updates)
-        cleanup_needed = True
+        timed_out = await run_with_optional_job_timeout(_iterate_refine_pipeline(job_id, request), timeout)
+        if timed_out:
+            current_job = session_manager.get_job(job_id)
+            if current_job is None:
+                return
+            msg = f"Refine job exceeded timeout of {timeout}s"
+            error_event = ProgressEvent("error", "error", msg, current_job.progress)
+            for payload, updates in payloads_from_progress_event(job_id, current_job, error_event):
+                session_manager.record_event(job_id, payload, **updates)
+            cleanup_needed = True
     except asyncio.CancelledError:
         session_manager.mark_job_cancelled(job_id, "Refine job cancelled")
         cleanup_needed = True

--- a/backend/config.py
+++ b/backend/config.py
@@ -131,9 +131,10 @@ class Settings(BaseSettings):
     # Number of parallel equation renders allowed in flight.
     equation_render_concurrency: int = 4
     agent_runtime_ready_timeout: int = 30
-    # Max time an Agent SDK turn may stay silent before the backend treats it
-    # as stuck and interrupts the turn. Set <=0 to disable.
-    agent_turn_idle_timeout: int = 300
+    # Optional hard limit for Agent SDK stream silence. Disabled by default so
+    # long-running Codex/Claude turns are surfaced through idle notices instead
+    # of being stopped as failures. Set >0 to re-enable a hard stop.
+    agent_turn_idle_timeout: int = 0
 
     # ── WebSocket ────────────────────────────────────────────────────────
     ws_subscriber_queue_size: int = 1024

--- a/backend/llm/provider_openai.py
+++ b/backend/llm/provider_openai.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import httpx
 from openai import AsyncOpenAI
+from openai.lib._parsing import type_to_response_format_param
 from pydantic import BaseModel
 
 from backend.config import settings
@@ -511,6 +512,27 @@ class OpenAIProvider(LLMProvider):
         buffered_kwargs.pop("stream_options", None)
         return await self._client.chat.completions.create(**buffered_kwargs)
 
+    def _chat_kwargs_with_response_format(
+        self,
+        kwargs: dict,
+        response_format: type[BaseModel],
+    ) -> dict:
+        structured_kwargs = dict(kwargs)
+        structured_kwargs["response_format"] = type_to_response_format_param(
+            response_format
+        )
+        return structured_kwargs
+
+    def _attach_parsed_response_format(
+        self,
+        resp,
+        response_format: type[BaseModel],
+    ):
+        content = resp.choices[0].message.content or ""
+        parsed = response_format.model_validate_json(content)
+        resp.choices[0].message.parsed = parsed
+        return resp
+
     async def _consume_chat_stream(self, kwargs: dict):
         """Run a chat completion in streaming mode, accumulating it into a
         non-streaming response shape the rest of ``chat()`` already expects.
@@ -599,12 +621,40 @@ class OpenAIProvider(LLMProvider):
         kwargs: dict,
         response_format: type[BaseModel],
     ):
+        structured_kwargs = self._chat_kwargs_with_response_format(
+            kwargs,
+            response_format,
+        )
+        try:
+            resp = await call_with_retry(
+                lambda: self._consume_chat_stream(structured_kwargs)
+            )
+            return self._attach_parsed_response_format(resp, response_format)
+        except BaseException as exc:
+            if self._should_use_raw_compat_fallback(structured_kwargs, exc):
+                resp = await self._create_raw_chat_completion(structured_kwargs)
+                return self._attach_parsed_response_format(resp, response_format)
+            fallbacks = self._fallback_chat_kwargs(structured_kwargs)
+            if not fallbacks or not self._is_parameter_compat_error(exc):
+                raise
+            for index, fallback in enumerate(fallbacks):
+                try:
+                    resp = await call_with_retry(
+                        lambda: self._consume_chat_stream(fallback)
+                    )
+                    return self._attach_parsed_response_format(resp, response_format)
+                except BaseException as fallback_exc:
+                    if (
+                        index >= len(fallbacks) - 1
+                        or not self._is_parameter_compat_error(fallback_exc)
+                    ):
+                        raise
+            raise
+
+    async def _create_stream(self, kwargs: dict):
         try:
             return await call_with_retry(
-                lambda: self._client.beta.chat.completions.parse(
-                    **kwargs,
-                    response_format=response_format,
-                )
+                lambda: self._client.chat.completions.create(**kwargs)
             )
         except BaseException as exc:
             fallbacks = self._fallback_chat_kwargs(kwargs)
@@ -613,10 +663,7 @@ class OpenAIProvider(LLMProvider):
             for index, fallback in enumerate(fallbacks):
                 try:
                     return await call_with_retry(
-                        lambda: self._client.beta.chat.completions.parse(
-                            **fallback,
-                            response_format=response_format,
-                        )
+                        lambda: self._client.chat.completions.create(**fallback)
                     )
                 except BaseException as fallback_exc:
                     if (
@@ -734,24 +781,7 @@ class OpenAIProvider(LLMProvider):
         )
 
         async with llm_request_slot():
-            stream = None
-            try:
-                stream = await self._client.chat.completions.create(**kwargs)
-            except BaseException as exc:
-                fallbacks = self._fallback_chat_kwargs(kwargs)
-                if not fallbacks or not self._is_parameter_compat_error(exc):
-                    raise
-                for index, fallback in enumerate(fallbacks):
-                    try:
-                        stream = await self._client.chat.completions.create(**fallback)
-                        break
-                    except BaseException as fallback_exc:
-                        if (
-                            index >= len(fallbacks) - 1
-                            or not self._is_parameter_compat_error(fallback_exc)
-                        ):
-                            raise
-            assert stream is not None
+            stream = await self._create_stream(kwargs)
             async for chunk in stream:
                 delta = chunk.choices[0].delta
                 if delta.content:

--- a/backend/runtime/job_timeout.py
+++ b/backend/runtime/job_timeout.py
@@ -1,0 +1,34 @@
+"""Helpers for applying an optional whole-job timeout."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+
+
+async def run_with_optional_job_timeout(awaitable: Awaitable[None], timeout: float | None) -> bool:
+    """Run *awaitable* and return True only when the whole-job timeout elapsed.
+
+    ``asyncio.wait_for`` cannot distinguish its own timeout from a
+    ``TimeoutError`` raised by the awaited job. Waiting on an explicit task
+    keeps internal timeout failures visible to the caller's normal exception
+    path instead of reporting them as whole-job timeouts.
+    """
+    if not timeout or timeout <= 0:
+        await awaitable
+        return False
+
+    task = asyncio.create_task(awaitable)
+    try:
+        done, _ = await asyncio.wait({task}, timeout=timeout)
+        if task in done:
+            await task
+            return False
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        return True
+    except BaseException:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        raise

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -1535,6 +1535,13 @@ function UploadCard({
     setSkipGuideNextTime(false);
   }, [mode]);
 
+  useEffect(() => {
+    if (!uploading) return;
+    setGuideMode(null);
+    setPendingFile(null);
+    setSkipGuideNextTime(false);
+  }, [uploading]);
+
   const requestFileSelection = () => {
     if (dismissedGuides[mode]) {
       inputRef.current?.click();
@@ -1554,10 +1561,14 @@ function UploadCard({
     if (pendingFile) {
       const file = pendingFile;
       setPendingFile(null);
-      void handleFile(file);
+      window.setTimeout(() => {
+        void handleFile(file);
+      }, 0);
       return;
     }
-    inputRef.current?.click();
+    window.setTimeout(() => {
+      inputRef.current?.click();
+    }, 0);
   };
 
   const onDragOver = (event: DragEvent<HTMLDivElement>) => {

--- a/tests/test_job_timeout.py
+++ b/tests/test_job_timeout.py
@@ -1,0 +1,32 @@
+import asyncio
+
+import pytest
+
+from backend.runtime.job_timeout import run_with_optional_job_timeout
+
+
+def test_internal_timeout_error_is_not_treated_as_job_timeout():
+    async def raises_timeout() -> None:
+        raise TimeoutError("inner agent timeout")
+
+    with pytest.raises(TimeoutError, match="inner agent timeout"):
+        asyncio.run(run_with_optional_job_timeout(raises_timeout(), timeout=30))
+
+
+def test_whole_job_timeout_returns_true():
+    async def hangs() -> None:
+        await asyncio.sleep(10)
+
+    assert asyncio.run(run_with_optional_job_timeout(hangs(), timeout=0.01)) is True
+
+
+def test_disabled_job_timeout_waits_normally():
+    completed = False
+
+    async def finishes() -> None:
+        nonlocal completed
+        await asyncio.sleep(0)
+        completed = True
+
+    assert asyncio.run(run_with_optional_job_timeout(finishes(), timeout=None)) is False
+    assert completed is True

--- a/tests/test_openai_provider_streaming.py
+++ b/tests/test_openai_provider_streaming.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from backend.llm.provider_openai import OpenAIProvider
+from backend.llm.types import LLMMessage
+
+
+class _StructuredResult(BaseModel):
+    name: str
+
+
+class _RetryableError(RuntimeError):
+    status_code = 500
+
+
+class _AsyncStream:
+    def __init__(self, chunks: list[SimpleNamespace]) -> None:
+        self._chunks = chunks
+
+    def __aiter__(self):
+        self._iter = iter(self._chunks)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _FakeCompletions:
+    def __init__(self, outcomes: list[object]) -> None:
+        self.outcomes = outcomes
+        self.calls: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+def _provider(completions: _FakeCompletions) -> OpenAIProvider:
+    provider = object.__new__(OpenAIProvider)
+    provider._client = SimpleNamespace(
+        chat=SimpleNamespace(completions=completions)
+    )
+    provider._api_key = "test"
+    provider._provider_name = "openai"
+    provider._base_url = ""
+    provider._deepseek_settings = None
+    provider._openai_settings = None
+    provider._streaming_unsupported = False
+    return provider
+
+
+def _chunk(
+    content: str | None = None,
+    *,
+    usage: SimpleNamespace | None = None,
+    finish_reason: str | None = None,
+) -> SimpleNamespace:
+    choices = []
+    if content is not None or finish_reason is not None:
+        choices.append(
+            SimpleNamespace(
+                delta=SimpleNamespace(content=content),
+                finish_reason=finish_reason,
+            )
+        )
+    return SimpleNamespace(
+        id="resp_1",
+        model="gpt-test",
+        usage=usage,
+        choices=choices,
+    )
+
+
+@pytest.mark.asyncio
+async def test_response_format_uses_streaming_and_attaches_parsed() -> None:
+    stream = _AsyncStream([
+        _chunk('{"name":'),
+        _chunk('"deck"}', finish_reason="stop"),
+        _chunk(
+            usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7),
+        ),
+    ])
+    completions = _FakeCompletions([stream])
+    provider = _provider(completions)
+
+    response = await provider.chat(
+        [LLMMessage.user("return json")],
+        "gpt-test",
+        response_format=_StructuredResult,
+    )
+
+    assert response.content == '{"name":"deck"}'
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == 11
+    assert response.usage.completion_tokens == 7
+    assert response.raw.choices[0].message.parsed == _StructuredResult(name="deck")
+    assert completions.calls[0]["stream"] is True
+    assert completions.calls[0]["stream_options"] == {"include_usage": True}
+    assert isinstance(completions.calls[0]["response_format"], dict)
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_creation_uses_shared_retry() -> None:
+    stream = _AsyncStream([
+        _chunk("hello", finish_reason="stop"),
+    ])
+    completions = _FakeCompletions([
+        _RetryableError("upstream unavailable"),
+        stream,
+    ])
+    provider = _provider(completions)
+
+    chunks = [
+        chunk
+        async for chunk in provider.chat_stream(
+            [LLMMessage.user("hi")],
+            "gpt-test",
+        )
+    ]
+
+    assert [chunk.delta for chunk in chunks] == ["hello"]
+    assert len(completions.calls) == 2


### PR DESCRIPTION
## Summary
- Bring dev up to master with the structured streaming retry merge
- Keep Agent idle turns from hard failing and avoid misreporting internal timeouts as job timeouts

## Tests
- PYTHONPATH=. pytest tests/test_job_timeout.py
- python -m py_compile backend/runtime/job_timeout.py backend/api/endpoints/generate.py backend/api/endpoints/refine.py backend/config.py