### PR TITLE
Fix SVG preview stability

### DIFF
--- a/backend/api/endpoints/download.py
+++ b/backend/api/endpoints/download.py
@@ -181,7 +181,23 @@ def _edited_pptist_deck(project_dir: Path | None) -> Path | None:
     if project_dir is None:
         return None
     deck = project_dir / "pptist" / "current.pptx"
-    return deck if deck.exists() else None
+    state_path = project_dir / "pptist" / "save_state.json"
+    if not deck.exists() or not state_path.exists():
+        return None
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(state, dict) or state.get("download_ready") is not True:
+        return None
+    if state.get("current_pptx") != str(deck):
+        return None
+    try:
+        if state_path.stat().st_mtime_ns < deck.stat().st_mtime_ns:
+            return None
+    except OSError:
+        return None
+    return deck
 
 
 def _download_filename(project_dir: Path | None, path: Path) -> str:

--- a/backend/api/endpoints/preview.py
+++ b/backend/api/endpoints/preview.py
@@ -17,7 +17,10 @@ from pydantic import BaseModel, Field
 
 from backend.api.schemas import PreviewResponse, PreviewSlide
 from backend.config import settings
-from backend.generator.project_manager import get_svg_files
+from backend.generator.project_manager import (
+    get_svg_files,
+    slide_index_from_svg_path as project_slide_index_from_svg_path,
+)
 from backend.generator.pptx_sanitize import sanitize_pptx_bytes, validate_pptx_xml
 from backend.generator.pptx_scene import (
     SceneError,
@@ -226,6 +229,7 @@ async def save_pptist_preview_deck(job_id: str, payload: PptistDeckSaveRequest) 
 async def export_pptist_preview_deck(job_id: str, file: UploadFile = File(...)) -> dict[str, Any]:
     job = session_manager.get_job(job_id)
     project_dir = _preview_project_dir_for_id(job_id, job)
+    previous_output_path = job.output_path if job else None
     data = await file.read()
     if not data:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Exported PPTX is empty.")
@@ -245,10 +249,32 @@ async def export_pptist_preview_deck(job_id: str, file: UploadFile = File(...)) 
     export_path = exports_dir / f"presentation_pptist_{timestamp}.pptx"
     await awrite_bytes(export_path, data)
     render_info = await _refresh_preview_svg_render(project_dir, current_pptx)
+    scene_cache_ready = True
     try:
         await aoffload(ensure_scene_cache, current_pptx, _project_scene_paths(project_dir), force=True, render=False)
     except Exception as exc:  # pragma: no cover - invalid uploads or parser gaps should not block saving.
+        scene_cache_ready = False
         render_info.setdefault("warnings", []).append(f"PPTist scene cache refresh skipped: {exc}")
+    download_ready = render_info.get("render_status") != "skipped" and scene_cache_ready
+    published_output_path = (
+        str(current_pptx)
+        if download_ready
+        else _stable_output_after_pptist_save(project_dir, previous_output_path, current_pptx)
+    )
+    await _write_pptist_save_state(
+        project_dir,
+        {
+            "version": 1,
+            "updated_at": _utc_now(),
+            "current_pptx": str(current_pptx),
+            "export_path": str(export_path),
+            "download_ready": download_ready,
+            "published_output_path": published_output_path,
+            "render_status": render_info.get("render_status") or "complete",
+            "scene_cache_ready": scene_cache_ready,
+            "warnings": render_info.get("warnings", []),
+        },
+    )
     deck = await _read_pptist_deck(project_dir)
     slide_count = len(deck.get("slides") or []) if deck else 0
     if job is not None:
@@ -256,16 +282,17 @@ async def export_pptist_preview_deck(job_id: str, file: UploadFile = File(...)) 
             job_id,
             status="complete",
             message="Presentation saved from PPTist",
-            output_path=str(current_pptx),
+            output_path=published_output_path,
             error=None,
         )
     return {
         "status": "complete",
-        "output_path": str(current_pptx),
+        "output_path": published_output_path,
         "export_path": str(export_path),
         "slide_count": render_info.get("slide_count") or slide_count,
         "updated_at": _utc_now(),
         "warnings": render_info.get("warnings", []),
+        "download_ready": download_ready,
     }
 
 
@@ -630,10 +657,13 @@ async def _build_preview_response_locked(
     if project_dir and project_dir.exists():
         final_files = get_svg_files(project_dir, "final")
         output_files = get_svg_files(project_dir, "output")
-        slide_files = final_files or output_files
+        use_output = bool(output_files) and (
+            not final_files or _latest_svg_mtime(output_files) > _latest_svg_mtime(final_files)
+        )
+        slide_files = output_files if use_output else final_files
         if last_slide_only and slide_files:
             slide_files = slide_files[-1:]
-        source = "final" if final_files else "output"
+        source = "output" if use_output else "final"
         scene_source = _scene_source_pptx(project_dir, output_path, _project_scene_paths(project_dir))
         scene_paths_for_project = _project_scene_paths(project_dir) if scene_source is not None else None
         scene_slide_indexes = await _available_scene_slide_indexes_async(scene_source, scene_paths_for_project) if scene_source is not None and scene_paths_for_project is not None else set()
@@ -741,6 +771,18 @@ async def _write_pptist_deck(project_dir: Path, deck: dict[str, Any]) -> None:
     )
 
 
+async def _write_pptist_save_state(project_dir: Path, state: dict[str, Any]) -> None:
+    await awrite_text(
+        _pptist_dir(project_dir) / "save_state.json",
+        json.dumps(state, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _latest_svg_mtime(svg_files: list[Path]) -> int:
+    return max((_safe_mtime_version(path) for path in svg_files), default=0)
+
+
 async def _refresh_preview_svg_render(project_dir: Path, pptx_path: Path) -> dict[str, Any]:
     warnings: list[str] = []
     tmp_dir = _pptist_dir(project_dir) / "render_svg_tmp"
@@ -817,13 +859,7 @@ def _model_dump(model: Any) -> dict[str, Any]:
 
 
 def _slide_index_from_svg_path(svg_path: Path, fallback_index: int) -> int:
-    match = re.match(r"^0*(\d+)(?:_|$)", svg_path.stem)
-    if not match:
-        return fallback_index
-    try:
-        return int(match.group(1))
-    except ValueError:
-        return fallback_index
+    return project_slide_index_from_svg_path(svg_path, fallback_index) or fallback_index
 
 
 def _delete_svg_slide_assets(project_dir: Path, svg_path: Path) -> None:
@@ -946,6 +982,36 @@ def _find_latest_output(project_dir: Path) -> Path | None:
     return candidates[0] if candidates else None
 
 
+def _find_latest_stable_output(project_dir: Path) -> Path | None:
+    exports_dir = project_dir / "exports"
+    if not exports_dir.exists():
+        return None
+    candidates = sorted(
+        (
+            path for path in exports_dir.glob("*.pptx")
+            if not path.name.startswith("presentation_pptist_")
+        ),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _stable_output_after_pptist_save(
+    project_dir: Path,
+    previous_output_path: str | None,
+    current_pptx: Path,
+) -> str:
+    if previous_output_path:
+        previous = _resolve_workspace_file(previous_output_path)
+        if previous is not None and previous.exists() and previous != current_pptx:
+            return str(previous)
+    stable = _find_latest_stable_output(project_dir)
+    if stable is not None:
+        return str(stable)
+    return str(current_pptx)
+
+
 def _project_scene_paths(project_dir: Path):
     return scene_paths(project_dir / "pptx_scene")
 
@@ -1046,8 +1112,6 @@ def _viewable_project_dir_for_id(job_id: str, job) -> Path:
 def _viewable_project_dir(job) -> Path:
     if job is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found.")
-    if job.status not in {"complete", "error", "cancelled"}:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Presentation preview is not ready yet.")
     if not job.project_dir:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Job has no project workspace.")
     project_dir = _resolve_workspace_path(job.project_dir)

--- a/backend/generator/project_manager.py
+++ b/backend/generator/project_manager.py
@@ -6,6 +6,7 @@ SVG generation → post-processing → PPTX export pipeline.
 
 from __future__ import annotations
 
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -210,7 +211,7 @@ def prepare_for_finalize(project_dir: Path) -> None:
         shutil.rmtree(svg_final)
     svg_final.mkdir()
 
-    for svg_file in sorted(svg_output.glob("*.svg")):
+    for svg_file in get_svg_files(project_dir, "output"):
         shutil.copy2(svg_file, svg_final / svg_file.name)
 
     sync_svg_output_assets_to_final(project_dir)
@@ -257,11 +258,52 @@ def get_svg_files(project_dir: Path, source: str = "final") -> list[Path]:
     svg_dir = project_dir / f"svg_{source}"
     if not svg_dir.exists():
         return []
-    return sorted(
+    candidates = sorted(
         path
         for path in svg_dir.glob("*.svg")
         if not path.name.startswith(".__render_") and not path.name.startswith(".__preview_")
     )
+    indexed: dict[int, Path] = {}
+    unindexed: list[Path] = []
+    for path in candidates:
+        index = slide_index_from_svg_path(path)
+        if index is None or index < 1:
+            unindexed.append(path)
+            continue
+        current = indexed.get(index)
+        if current is None or _svg_candidate_rank(path) > _svg_candidate_rank(current):
+            indexed[index] = path
+    return [indexed[index] for index in sorted(indexed)] + unindexed
+
+
+def _svg_candidate_rank(path: Path) -> tuple[int, int, str]:
+    """Prefer the newest file when multiple names represent one slide."""
+    try:
+        modified = path.stat().st_mtime_ns
+    except OSError:
+        modified = 0
+    canonical = int(bool(re.fullmatch(r"slide[_-]\d+", path.stem, re.IGNORECASE)))
+    return modified, canonical, path.name
+
+
+_SLIDE_INDEX_PATTERNS = (
+    re.compile(r"^0*(\d+)(?:[_-]|$)", re.IGNORECASE),
+    re.compile(r"^slide[_-]0*(\d+)(?:[_-]|$)", re.IGNORECASE),
+)
+
+
+def slide_index_from_svg_path(svg_path: Path, fallback_index: int | None = None) -> int | None:
+    """Return the 1-based slide index encoded in common SVG filenames."""
+    stem = Path(svg_path).stem
+    for pattern in _SLIDE_INDEX_PATTERNS:
+        match = pattern.match(stem)
+        if not match:
+            continue
+        try:
+            return int(match.group(1))
+        except ValueError:
+            break
+    return fallback_index
 
 
 def get_notes(project_dir: Path, svg_files: list[Path]) -> dict[str, str]:

--- a/backend/orchestrator/svg_executor.py
+++ b/backend/orchestrator/svg_executor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import uuid
 import xml.etree.ElementTree as ET
 from collections import Counter
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -21,6 +22,7 @@ from pathlib import Path
 from PIL import Image
 
 from backend.config import settings
+from backend.generator.project_manager import get_svg_files, slide_index_from_svg_path
 from backend.generator.svg_critic import CriticConfig, CriticReport, Violation, check_svg
 from backend.generator.visual_critic import VisualCriticConfig, visual_check
 from backend.llm import LLMMessage, LLMProvider, LLMResponse
@@ -2551,20 +2553,39 @@ def _load_existing_svg_history(
     pages: list[str],
 ) -> dict[int, tuple[str, str, str]]:
     history: dict[int, tuple[str, str, str]] = {}
-    for page_num, page in enumerate(pages, start=1):
-        matches = sorted(svg_output_dir.glob(f"{page_num:02d}_*.svg"))
-        if not matches:
+    project_dir = svg_output_dir.parent
+    for fallback_index, svg_path in enumerate(get_svg_files(project_dir, "output"), start=1):
+        page_num = slide_index_from_svg_path(svg_path, fallback_index)
+        if page_num is None or page_num < 1 or page_num > len(pages) or page_num in history:
             continue
         try:
-            svg_content = matches[0].read_text(encoding="utf-8")
+            svg_content = svg_path.read_text(encoding="utf-8")
         except OSError:
             continue
+        page = pages[page_num - 1]
         history[page_num] = (
             _classify_page_type(page),
             _make_page_name(page_num, page),
             svg_content,
         )
     return history
+
+
+def _write_generated_svg(svg_output_dir: Path, page_num: int, svg_content: str) -> Path:
+    """Atomically replace every filename variant representing one slide."""
+    target = svg_output_dir / f"slide_{page_num:03d}.svg"
+    temporary = svg_output_dir / f".__slide_{page_num:03d}_{uuid.uuid4().hex}.svg"
+    temporary.write_text(svg_content, encoding="utf-8")
+    try:
+        for existing in svg_output_dir.glob("*.svg"):
+            if existing == temporary:
+                continue
+            if slide_index_from_svg_path(existing) == page_num:
+                existing.unlink(missing_ok=True)
+        temporary.replace(target)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return target
 
 
 def _same_type_svg_history_message(
@@ -3154,8 +3175,7 @@ async def generate_svg_pages(
                     conversation.append(LLMMessage.assistant(response.content))
                     break
 
-            svg_path = svg_output_dir / f"{page_num:02d}_{page_name}.svg"
-            svg_path.write_text(best_svg, encoding="utf-8")
+            _write_generated_svg(svg_output_dir, page_num, best_svg)
             generated_history[page_num] = (
                 page_type,
                 page_name,
@@ -4580,8 +4600,7 @@ async def _generate_parallel_page(
             conversation.append(LLMMessage.assistant(response.content))
             break
 
-    svg_path = svg_output_dir / f"{page_num:02d}_{page_name}.svg"
-    svg_path.write_text(best_svg, encoding="utf-8")
+    _write_generated_svg(svg_output_dir, page_num, best_svg)
     return page_num, best_svg
 
 

--- a/frontend/src/pptist/views/Editor/Canvas/index.vue
+++ b/frontend/src/pptist/views/Editor/Canvas/index.vue
@@ -178,7 +178,8 @@ watch(handleElementId, () => {
 
 const elementList = ref<PPTElement[]>([])
 const setLocalElementList = () => {
-  elementList.value = currentSlide.value ? JSON.parse(JSON.stringify(currentSlide.value.elements)) : []
+  const elements = currentSlide.value?.elements
+  elementList.value = Array.isArray(elements) ? JSON.parse(JSON.stringify(elements)) : []
 }
 watchEffect(setLocalElementList)
 

--- a/frontend/src/pptist/views/Mobile/MobileEditor/index.vue
+++ b/frontend/src/pptist/views/Mobile/MobileEditor/index.vue
@@ -98,7 +98,8 @@ const viewportStyles = computed(() => ({
 
 const elementList = ref<PPTElement[]>([])
 const setLocalElementList = () => {
-  elementList.value = currentSlide.value ? JSON.parse(JSON.stringify(currentSlide.value.elements)) : []
+  const elements = currentSlide.value?.elements
+  elementList.value = Array.isArray(elements) ? JSON.parse(JSON.stringify(elements)) : []
 }
 watchEffect(setLocalElementList)
 


### PR DESCRIPTION
## Summary
- Deduplicate SVG slide files by parsed page index across provider and canonical filename styles.
- Write regenerated SVGs as `slide_###.svg` and remove stale same-page filename variants.
- Keep preview available during active jobs and prefer newer `svg_output` over stale `svg_final`.
- Guard PPTist canvas element lists against missing/non-array `elements`.
- Gate `pptist/current.pptx` downloads behind an explicit `pptist/save_state.json` readiness marker so a failed PPTist refresh does not hijack downloads.

## Validation
- `python -m py_compile backend/api/endpoints/preview.py backend/api/endpoints/download.py backend/generator/project_manager.py backend/orchestrator/svg_executor.py`
- `python -m pytest tests/test_preview_svg_status.py tests/test_svg_executor_context.py`
- `npm run build`
