### PR TITLE
feat: vision model auto-probe, Tavily global config, env documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,16 @@ MINERU_API_URL=
 
 # Image generation (optional)
 IMAGE_BACKEND=gemini
+
+# Tavily API Key (for image search and deep research)
+TAVILY_API_KEY=
+
+# OpenAI-compatible base URL (optional, for custom providers)
+OPENAI_BASE_URL=
+
+# Vision QA: comma-separated models to probe for vision capability
+# Example: gpt-5.4,gpt-5.5,claude-sonnet-4.6
+VISION_MODELS=
+# Preferred vision-capable fallback model for visual QA
+# Example: gpt-5.4
+VISION_MODEL=

--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,5 @@ VISION_MODELS=
 # Preferred vision-capable fallback model for visual QA
 # Example: gpt-5.4
 VISION_MODEL=
+# Auto-switch to vision model during visual QA (agent mode only)
+VISION_AUTO_SWITCH=false

--- a/backend/api/endpoints/image_search.py
+++ b/backend/api/endpoints/image_search.py
@@ -44,9 +44,11 @@ async def search_images_endpoint(
 
     # Use client-provided key first, fall back to job config
     from backend.api.schemas import ResearchConfig
+    from backend.config import get_tavily_api_key
 
     tavily_key = request.tavily_api_key or _get_job_config(job, "tavily_api_key")
     serpapi_key = request.serpapi_key or _get_job_config(job, "serpapi_key")
+    tavily_key = get_tavily_api_key(tavily_key)
     config = ResearchConfig(
         tavily_api_key=tavily_key,
         serpapi_key=serpapi_key,

--- a/backend/app.py
+++ b/backend/app.py
@@ -53,6 +53,34 @@ def _cleanup_all_job_processes() -> None:
 
 atexit.register(_cleanup_all_job_processes)
 
+async def _probe_vision_models() -> None:
+    """Probe configured models for vision support at startup."""
+    from backend.config import get_provider_credentials
+    from backend.llm import create_provider
+    from backend.llm.vision_probe import vision_probe
+
+    models_str = (settings.vision_models or "").strip()
+    if not models_str:
+        logger.info("Vision probe: no VISION_MODELS configured, skipping")
+        return
+
+    models = [m.strip() for m in models_str.split(",") if m.strip()]
+    if not models:
+        return
+
+    provider_name, api_key, base_url = get_provider_credentials()
+
+    if not api_key:
+        logger.warning("Vision probe: no API key for provider '%s', skipping", provider_name)
+        return
+
+    try:
+        llm = create_provider(provider_name, api_key, base_url=base_url)
+        logger.info("Vision probe: testing %d models via %s ...", len(models), provider_name)
+        await vision_probe.probe_all(models, llm)
+    except Exception as exc:
+        logger.warning("Vision probe failed: %s", exc)
+
 
 def _install_signal_handlers() -> None:
     """Install signal handlers that trigger process cleanup before exit.
@@ -87,6 +115,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """
     _install_signal_handlers()
     init_offload(settings.io_pool_workers)
+
+    # ── Vision capability probe (background, non-blocking) ──
+    _probe_task = asyncio.create_task(_probe_vision_models())
+    _probe_task.add_done_callback(
+        lambda t: t.exception() and logger.warning("Vision probe task error: %s", t.exception())
+    )
     try:
         # Scheduler / EventBus are wired in here once their modules land
         # (kept opt-in so the import graph stays clean during the rollout).
@@ -160,6 +194,24 @@ def create_app() -> FastAPI:
         return {
             "name": "Paper PPT Agent",
             "frontend": "Open the Vite frontend to upload a paper PDF or TeX source package and generate a PPT draft.",
+        }
+
+    @app.get("/healthz/vision")
+    async def vision_probe_status() -> dict:
+        from backend.llm.vision_probe import vision_probe
+        results = vision_probe.all_results()
+        return {
+            "probed": vision_probe.is_probed(),
+            "models": {
+                k: {
+                    "model": v.model,
+                    "supports_vision": v.supports_vision,
+                    "response": v.response_excerpt[:60] if v.response_excerpt else None,
+                    "error": v.error[:80] if v.error else None,
+                }
+                for k, v in results.items()
+            },
+            "vision_model_fallback": vision_probe.get_vision_model(),
         }
 
     app.include_router(api_router)

--- a/backend/app.py
+++ b/backend/app.py
@@ -198,6 +198,7 @@ def create_app() -> FastAPI:
 
     @app.get("/healthz/vision")
     async def vision_probe_status() -> dict:
+        """Return vision capability probe results for all configured models."""
         from backend.llm.vision_probe import vision_probe
         results = vision_probe.all_results()
         return {

--- a/backend/config.py
+++ b/backend/config.py
@@ -69,6 +69,7 @@ class Settings(BaseSettings):
     default_llm_provider: Literal["openai", "deepseek", "anthropic", "gemini"] = "openai"
     default_llm_model: str = "gpt-4o"
     openai_api_key: str | None = None
+    openai_base_url: str | None = None
     deepseek_api_key: str | None = None
     anthropic_api_key: str | None = None
     gemini_api_key: str | None = None
@@ -79,6 +80,14 @@ class Settings(BaseSettings):
 
     # Image generation
     image_backend: str | None = None
+
+    # Tavily (image search & deep research)
+    tavily_api_key: str | None = None
+
+    # Vision QA: comma-separated list of models to probe for vision support,
+    # and the fallback model to use when the primary model lacks vision.
+    vision_models: str | None = None  # e.g. "gpt-5.4,gpt-5.5,claude-sonnet-4.6"
+    vision_model: str | None = None   # preferred fallback, e.g. "gpt-5.4"
 
     # Paths
     assets_dir: Path = PROJECT_ROOT / "assets"
@@ -157,3 +166,27 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+def get_tavily_api_key(per_request: str | None = None) -> str:
+    """Return the best available Tavily API key (per-request > global settings)."""
+    return (per_request or "").strip() or (settings.tavily_api_key or "").strip()
+
+
+
+def get_provider_credentials() -> tuple[str, str, str | None]:
+    """Return (provider_name, api_key, base_url) from current settings."""
+    from backend.llm.registry import DEEPSEEK_BASE_URL
+
+    name = settings.default_llm_provider or "openai"
+    _KEY_MAP = {
+        "openai": settings.openai_api_key,
+        "deepseek": settings.deepseek_api_key,
+        "anthropic": settings.anthropic_api_key,
+        "gemini": settings.gemini_api_key,
+    }
+    _URL_MAP = {
+        "openai": settings.openai_base_url or None,
+        "deepseek": DEEPSEEK_BASE_URL,
+    }
+    return name, (_KEY_MAP.get(name) or ""), _URL_MAP.get(name)

--- a/backend/config.py
+++ b/backend/config.py
@@ -88,6 +88,7 @@ class Settings(BaseSettings):
     # and the fallback model to use when the primary model lacks vision.
     vision_models: str | None = None  # e.g. "gpt-5.4,gpt-5.5,claude-sonnet-4.6"
     vision_model: str | None = None   # preferred fallback, e.g. "gpt-5.4"
+    vision_auto_switch: bool = False  # auto-switch to vision model during visual QA (agent mode only)
 
     # Paths
     assets_dir: Path = PROJECT_ROOT / "assets"

--- a/backend/generator/visual_critic.py
+++ b/backend/generator/visual_critic.py
@@ -19,7 +19,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 
-from backend.config import settings as _global_settings
+from backend.config import settings as _settings
 from backend.llm.vision_probe import vision_probe
 from backend.generator.svg_critic import CriticReport, Violation
 from backend.llm.base import LLMProvider
@@ -42,6 +42,11 @@ class VisualCriticConfig:
     # JPEG quality for VLM payload. PNG kept by default (lossless).
     use_jpeg: bool = True
     jpeg_quality: int = 80
+
+    # When True, automatically switch to a vision-capable model during
+    # visual QA if the primary model lacks vision support.
+    # Only effective in agent mode (controlled by settings.vision_auto_switch).
+    vision_auto_switch: bool = False
 
 
 def render_svg_to_png(svg_content: str, width: int = 1280) -> bytes | None:
@@ -199,33 +204,32 @@ async def visual_check(
     cfg = config or VisualCriticConfig()
     outcome = VisualCheckOutcome()
 
-    # ── Auto-switch to a vision-capable model if needed ──
+    # ── Auto-switch to a vision-capable model if enabled ──
     effective_model = model
-    probe_result = vision_probe.get_result(model)
-    if probe_result is not None and not probe_result.supports_vision:
-        fallback = vision_probe.get_vision_model(exclude=model)
-        if not fallback:
-            # No vision-capable model found in probe cache — skip
+    if cfg.vision_auto_switch:
+        probe_result = vision_probe.get_result(model)
+        if probe_result is not None and not probe_result.supports_vision:
+            fallback = vision_probe.get_vision_model(exclude=model)
+            if not fallback:
+                logger.info(
+                    "Visual QA skipped: model '%s' lacks vision and no fallback available",
+                    model,
+                )
+                outcome.skipped_reason = "no_vision_model_available"
+                return outcome
             logger.info(
-                "Visual QA skipped: model '%s' lacks vision and no fallback available",
-                model,
+                "Visual QA auto-switch: %s -> %s (probe-detected vision support)",
+                model, fallback,
             )
-            outcome.skipped_reason = "no_vision_model_available"
-            return outcome
-        logger.info(
-            "Visual QA auto-switch: %s -> %s (probe-detected vision support)",
-            model, fallback,
-        )
-        effective_model = fallback
-    elif probe_result is None:
-        # Probe hasn't run yet — try the configured vision_model as fallback
-        configured = (_global_settings.vision_model or "").strip()
-        if configured and configured.lower() != model.strip().lower():
-            logger.info(
-                "Visual QA pre-probe fallback: %s -> %s (configured vision_model)",
-                model, configured,
-            )
-            effective_model = configured
+            effective_model = fallback
+        elif probe_result is None:
+            configured = (_settings.vision_model or "").strip()
+            if configured and configured.lower() != model.strip().lower():
+                logger.info(
+                    "Visual QA pre-probe fallback: %s -> %s (configured vision_model)",
+                    model, configured,
+                )
+                effective_model = configured
 
     png = render_svg_to_png(svg_content, width=cfg.render_width)
     if png is None:

--- a/backend/generator/visual_critic.py
+++ b/backend/generator/visual_critic.py
@@ -19,6 +19,8 @@ import logging
 import re
 from dataclasses import dataclass, field
 
+from backend.config import settings as _global_settings
+from backend.llm.vision_probe import vision_probe
 from backend.generator.svg_critic import CriticReport, Violation
 from backend.llm.base import LLMProvider
 from backend.llm.types import LLMMessage
@@ -197,6 +199,34 @@ async def visual_check(
     cfg = config or VisualCriticConfig()
     outcome = VisualCheckOutcome()
 
+    # ── Auto-switch to a vision-capable model if needed ──
+    effective_model = model
+    probe_result = vision_probe.get_result(model)
+    if probe_result is not None and not probe_result.supports_vision:
+        fallback = vision_probe.get_vision_model(exclude=model)
+        if not fallback:
+            # No vision-capable model found in probe cache — skip
+            logger.info(
+                "Visual QA skipped: model '%s' lacks vision and no fallback available",
+                model,
+            )
+            outcome.skipped_reason = "no_vision_model_available"
+            return outcome
+        logger.info(
+            "Visual QA auto-switch: %s -> %s (probe-detected vision support)",
+            model, fallback,
+        )
+        effective_model = fallback
+    elif probe_result is None:
+        # Probe hasn't run yet — try the configured vision_model as fallback
+        configured = (_global_settings.vision_model or "").strip()
+        if configured and configured.lower() != model.strip().lower():
+            logger.info(
+                "Visual QA pre-probe fallback: %s -> %s (configured vision_model)",
+                model, configured,
+            )
+            effective_model = configured
+
     png = render_svg_to_png(svg_content, width=cfg.render_width)
     if png is None:
         outcome.skipped_reason = "render_failed_or_unavailable"
@@ -220,7 +250,7 @@ async def visual_check(
     ]
 
     try:
-        response = await llm.chat(messages, model, temperature=0.0, max_tokens=1024)
+        response = await llm.chat(messages, effective_model, temperature=0.0, max_tokens=1024)
     except Exception as exc:  # noqa: BLE001 — provider may not support vision
         logger.info("Visual critic LLM call failed (likely text-only model): %s", exc)
         outcome.skipped_reason = "llm_call_failed"

--- a/backend/llm/vision_probe.py
+++ b/backend/llm/vision_probe.py
@@ -1,0 +1,179 @@
+"""Vision capability probe for LLM models.
+
+Sends a small JPEG test image to each configured model to determine whether
+it supports multimodal (vision) input.  Results are cached in memory so each
+model is only probed once per process lifetime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_EXPECTED_COLORS = {"red", "green", "blue", "white", "black", "yellow", "orange", "purple", "pink", "gray", "grey"}
+
+_VISION_SYSTEM = "You are a helpful vision assistant. Describe images accurately."
+_VISION_PROMPT = "What color is the square in this image? Reply with just the color name."
+_TEST_IMAGE: bytes | None = None
+
+
+def _get_test_image() -> bytes:
+    """Generate a 64x64 red-square JPEG (≈5 KB) on first use."""
+    global _TEST_IMAGE
+    if _TEST_IMAGE is not None:
+        return _TEST_IMAGE
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", (64, 64), color=(255, 255, 255))
+    ImageDraw.Draw(img).rectangle([8, 8, 56, 56], fill=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=80)
+    _TEST_IMAGE = buf.getvalue()
+    return _TEST_IMAGE
+
+
+@dataclass
+class ModelVisionResult:
+    model: str
+    supports_vision: bool
+    tested_at: float = 0.0
+    error: str | None = None
+    response_excerpt: str = ""
+
+
+_PROBE_TIMEOUT_SECONDS = 20.0
+
+
+class VisionProbe:
+    """Probes LLM models for vision support and caches results."""
+
+    def __init__(self) -> None:
+        self._cache: dict[str, ModelVisionResult] = {}
+        self._probed = False
+
+    def is_probed(self) -> bool:
+        return self._probed
+
+    def get_result(self, model: str) -> ModelVisionResult | None:
+        return self._cache.get(model.strip().lower())
+
+    def supports_vision(self, model: str) -> bool | None:
+        """True/False if probed, None if unknown."""
+        r = self.get_result(model)
+        return r.supports_vision if r else None
+
+    def get_vision_model(self, exclude: str = "") -> str | None:
+        """Return a model known to support vision (prefers settings.vision_model)."""
+        from backend.config import settings
+
+        exclude_lower = exclude.strip().lower()
+        # Prefer the explicitly configured vision_model
+        preferred = (settings.vision_model or "").strip()
+        if preferred:
+            r = self._cache.get(preferred.lower())
+            if r and r.supports_vision and preferred.lower() != exclude_lower:
+                return r.model
+        # Fall back to any vision-capable model in the cache
+        for key, r in self._cache.items():
+            if r.supports_vision and key != exclude_lower:
+                return r.model
+        return None
+
+    def all_results(self) -> dict[str, ModelVisionResult]:
+        return dict(self._cache)
+
+    async def probe_model(self, model: str, llm: Any) -> ModelVisionResult:
+        key = model.strip().lower()
+        if key in self._cache:
+            return self._cache[key]
+
+        MAX_RETRIES = 10
+        t0 = time.monotonic()
+        try:
+            from backend.llm.types import LLMMessage
+
+            image_bytes = _get_test_image()
+            messages = [
+                LLMMessage.system(_VISION_SYSTEM),
+                LLMMessage.user_with_image(
+                    _VISION_PROMPT, image_bytes, media_type="image/jpeg"
+                ),
+            ]
+            content = ""
+            for attempt in range(MAX_RETRIES):
+                try:
+                    response = await asyncio.wait_for(
+                        llm.chat(messages, model, temperature=0.0, max_tokens=32),
+                        timeout=_PROBE_TIMEOUT_SECONDS,
+                    )
+                    content = (response.content or "").strip().lower()
+                    if content:
+                        break
+                except Exception as retry_exc:
+                    err_text = str(retry_exc).lower()
+                    # 404 or timeout = definitively no vision support, stop retrying
+                    if "404" in err_text or "not found" in err_text or "timeout" in err_text:
+                        raise retry_exc
+                    # Other errors: retry
+                    logger.debug("Vision probe [%s] attempt %d error: %s", model, attempt + 1, str(retry_exc)[:80])
+                if attempt < MAX_RETRIES - 1:
+                    await asyncio.sleep(1.0)
+            # Validate that the model actually "saw" the image by checking
+            # whether its answer contains the expected color word.
+            supports = any(c in content for c in _EXPECTED_COLORS)
+            result = ModelVisionResult(
+                model=model,
+                supports_vision=supports,
+                tested_at=time.time(),
+                response_excerpt=content[:100],
+            )
+            logger.info(
+                "Vision probe [%s]: %s (%.1fs) response=%r",
+                model,
+                "SUPPORTED" if supports else "NOT supported",
+                time.monotonic() - t0,
+                content[:60],
+            )
+        except Exception as exc:
+            result = ModelVisionResult(
+                model=model,
+                supports_vision=False,
+                tested_at=time.time(),
+                error=str(exc)[:200],
+            )
+            logger.info(
+                "Vision probe [%s]: FAILED (%.1fs) error=%s",
+                model,
+                time.monotonic() - t0,
+                str(exc)[:80],
+            )
+        self._cache[key] = result
+        return result
+
+    async def probe_all(
+        self,
+        models: list[str],
+        llm: Any,
+    ) -> dict[str, ModelVisionResult]:
+        for m in models:
+            await self.probe_model(m, llm)
+        self._probed = True
+        supported = [r.model for r in self._cache.values() if r.supports_vision]
+        not_supported = [r.model for r in self._cache.values() if not r.supports_vision]
+        logger.info(
+            "Vision probe complete: %d supported %s, %d not supported %s",
+            len(supported),
+            supported,
+            len(not_supported),
+            not_supported,
+        )
+        return self._cache
+
+
+vision_probe = VisionProbe()

--- a/backend/llm/vision_probe.py
+++ b/backend/llm/vision_probe.py
@@ -1,7 +1,7 @@
 """Vision capability probe for LLM models.
 
 Sends a small JPEG test image to each configured model to determine whether
-it supports multimodal (vision) input.  Results are cached in memory so each
+it supports multimodal (vision) input. Results are cached in memory so each
 model is only probed once per process lifetime.
 """
 
@@ -10,36 +10,53 @@ from __future__ import annotations
 import asyncio
 import io
 import logging
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_EXPECTED_COLORS = {"red", "green", "blue", "white", "black", "yellow", "orange", "purple", "pink", "gray", "grey"}
+# Words that indicate the model correctly identified the red square.
+_EXPECTED_COLORS = frozenset({
+    "red", "crimson", "scarlet", "ruby", "cherry", "vermilion",
+})
+# Words that indicate the model cannot see images.
+_NO_VISION_INDICATORS = frozenset({
+    "cannot see", "can't see", "no image", "unable to view",
+    "not able to see", "don't see", "no picture",
+})
 
 _VISION_SYSTEM = "You are a helpful vision assistant. Describe images accurately."
 _VISION_PROMPT = "What color is the square in this image? Reply with just the color name."
-_TEST_IMAGE: bytes | None = None
+
+# Thread-safe lazy-initialized test image.
+_test_image_lock = threading.Lock()
+_test_image_cache: bytes | None = None
 
 
 def _get_test_image() -> bytes:
-    """Generate a 64x64 red-square JPEG (≈5 KB) on first use."""
-    global _TEST_IMAGE
-    if _TEST_IMAGE is not None:
-        return _TEST_IMAGE
-    from PIL import Image, ImageDraw
+    """Generate a 64x64 red-square JPEG on first use (thread-safe)."""
+    global _test_image_cache
+    if _test_image_cache is not None:
+        return _test_image_cache
+    with _test_image_lock:
+        if _test_image_cache is not None:
+            return _test_image_cache
+        from PIL import Image, ImageDraw
 
-    img = Image.new("RGB", (64, 64), color=(255, 255, 255))
-    ImageDraw.Draw(img).rectangle([8, 8, 56, 56], fill=(255, 0, 0))
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=80)
-    _TEST_IMAGE = buf.getvalue()
-    return _TEST_IMAGE
+        img = Image.new("RGB", (64, 64), color=(255, 255, 255))
+        ImageDraw.Draw(img).rectangle([8, 8, 56, 56], fill=(255, 0, 0))
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=80)
+        _test_image_cache = buf.getvalue()
+    return _test_image_cache
 
 
 @dataclass
 class ModelVisionResult:
+    """Result of a vision probe for a single model."""
+
     model: str
     supports_vision: bool
     tested_at: float = 0.0
@@ -47,21 +64,51 @@ class ModelVisionResult:
     response_excerpt: str = ""
 
 
-_PROBE_TIMEOUT_SECONDS = 20.0
+def _is_vision_response(content: str) -> bool:
+    """Check if a response indicates the model actually saw the image."""
+    if not content:
+        return False
+    # If the model explicitly says it can't see, it's not vision-capable.
+    if any(indicator in content for indicator in _NO_VISION_INDICATORS):
+        return False
+    # If the response contains a color word, it's vision-capable.
+    if any(color in content for color in _EXPECTED_COLORS):
+        return True
+    # Non-empty response without denial: likely vision-capable.
+    return len(content) > 2
 
 
 class VisionProbe:
-    """Probes LLM models for vision support and caches results."""
+    """Probes LLM models for vision support and caches results.
 
-    def __init__(self) -> None:
+    Thread-safe: cache mutations are protected by a lock.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_retries: int = 3,
+        probe_timeout: float = 20.0,
+        retry_delay: float = 1.0,
+    ) -> None:
         self._cache: dict[str, ModelVisionResult] = {}
+        self._lock = threading.Lock()
         self._probed = False
+        self._probe_complete = threading.Event()
+        self.max_retries = max_retries
+        self.probe_timeout = probe_timeout
+        self.retry_delay = retry_delay
 
     def is_probed(self) -> bool:
         return self._probed
 
+    def wait_probed(self, timeout: float | None = None) -> bool:
+        """Block until probe_all() completes. Returns True if completed."""
+        return self._probe_complete.wait(timeout=timeout)
+
     def get_result(self, model: str) -> ModelVisionResult | None:
-        return self._cache.get(model.strip().lower())
+        with self._lock:
+            return self._cache.get(model.strip().lower())
 
     def supports_vision(self, model: str) -> bool | None:
         """True/False if probed, None if unknown."""
@@ -73,27 +120,40 @@ class VisionProbe:
         from backend.config import settings
 
         exclude_lower = exclude.strip().lower()
-        # Prefer the explicitly configured vision_model
+        # Snapshot the cache to avoid iteration during concurrent mutation.
+        with self._lock:
+            cache_snapshot = dict(self._cache)
+
+        # Prefer the explicitly configured vision_model.
         preferred = (settings.vision_model or "").strip()
         if preferred:
-            r = self._cache.get(preferred.lower())
+            r = cache_snapshot.get(preferred.lower())
             if r and r.supports_vision and preferred.lower() != exclude_lower:
                 return r.model
-        # Fall back to any vision-capable model in the cache
-        for key, r in self._cache.items():
+
+        # Fall back to any vision-capable model in the cache.
+        for key, r in cache_snapshot.items():
             if r.supports_vision and key != exclude_lower:
                 return r.model
         return None
 
     def all_results(self) -> dict[str, ModelVisionResult]:
-        return dict(self._cache)
+        with self._lock:
+            return dict(self._cache)
+
+    def reset(self) -> None:
+        """Clear all cached probe results (useful for testing)."""
+        with self._lock:
+            self._cache.clear()
+            self._probed = False
+            self._probe_complete.clear()
 
     async def probe_model(self, model: str, llm: Any) -> ModelVisionResult:
         key = model.strip().lower()
-        if key in self._cache:
-            return self._cache[key]
+        with self._lock:
+            if key in self._cache:
+                return self._cache[key]
 
-        MAX_RETRIES = 10
         t0 = time.monotonic()
         try:
             from backend.llm.types import LLMMessage
@@ -106,27 +166,30 @@ class VisionProbe:
                 ),
             ]
             content = ""
-            for attempt in range(MAX_RETRIES):
+            last_error: Exception | None = None
+            for attempt in range(self.max_retries):
                 try:
                     response = await asyncio.wait_for(
                         llm.chat(messages, model, temperature=0.0, max_tokens=32),
-                        timeout=_PROBE_TIMEOUT_SECONDS,
+                        timeout=self.probe_timeout,
                     )
                     content = (response.content or "").strip().lower()
                     if content:
                         break
                 except Exception as retry_exc:
+                    last_error = retry_exc
                     err_text = str(retry_exc).lower()
-                    # 404 or timeout = definitively no vision support, stop retrying
-                    if "404" in err_text or "not found" in err_text or "timeout" in err_text:
+                    # 404 or timeout: definitively no vision support, stop retrying.
+                    if any(kw in err_text for kw in ("404", "not found", "timeout")):
                         raise retry_exc
-                    # Other errors: retry
-                    logger.debug("Vision probe [%s] attempt %d error: %s", model, attempt + 1, str(retry_exc)[:80])
-                if attempt < MAX_RETRIES - 1:
-                    await asyncio.sleep(1.0)
-            # Validate that the model actually "saw" the image by checking
-            # whether its answer contains the expected color word.
-            supports = any(c in content for c in _EXPECTED_COLORS)
+                    logger.debug(
+                        "Vision probe [%s] attempt %d error: %s",
+                        model, attempt + 1, str(retry_exc)[:80],
+                    )
+                if attempt < self.max_retries - 1:
+                    await asyncio.sleep(self.retry_delay)
+
+            supports = _is_vision_response(content)
             result = ModelVisionResult(
                 model=model,
                 supports_vision=supports,
@@ -153,7 +216,9 @@ class VisionProbe:
                 time.monotonic() - t0,
                 str(exc)[:80],
             )
-        self._cache[key] = result
+
+        with self._lock:
+            self._cache[key] = result
         return result
 
     async def probe_all(
@@ -164,8 +229,11 @@ class VisionProbe:
         for m in models:
             await self.probe_model(m, llm)
         self._probed = True
-        supported = [r.model for r in self._cache.values() if r.supports_vision]
-        not_supported = [r.model for r in self._cache.values() if not r.supports_vision]
+        self._probe_complete.set()
+
+        with self._lock:
+            supported = [r.model for r in self._cache.values() if r.supports_vision]
+            not_supported = [r.model for r in self._cache.values() if not r.supports_vision]
         logger.info(
             "Vision probe complete: %d supported %s, %d not supported %s",
             len(supported),
@@ -173,7 +241,7 @@ class VisionProbe:
             len(not_supported),
             not_supported,
         )
-        return self._cache
+        return self.all_results()
 
 
 vision_probe = VisionProbe()

--- a/backend/orchestrator/image_search.py
+++ b/backend/orchestrator/image_search.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from backend.api.schemas import ResearchConfig
+from backend.config import get_tavily_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ async def search_images(
 
     Returns a list of ImageSearchResult with URLs and thumbnails.
     """
-    tavily_key = (config.tavily_api_key or "").strip()
+    tavily_key = get_tavily_api_key(config.tavily_api_key)
     serpapi_key = (config.serpapi_key or "").strip()
 
     if not tavily_key and not serpapi_key:

--- a/backend/orchestrator/pipeline.py
+++ b/backend/orchestrator/pipeline.py
@@ -488,6 +488,15 @@ async def run_pipeline(
         async def _on_svg_update(page_num: int, svg: str) -> None:
             svg_update_queue.append((page_num, svg))
 
+        from backend.config import settings as _settings
+        from backend.generator.visual_critic import VisualCriticConfig
+
+        _visual_cfg = VisualCriticConfig(
+            vision_auto_switch=(
+                request.generation_backend == "agent"
+                and _settings.vision_auto_switch
+            ),
+        )
         if request.generation_mode == "sequential":
             svg_iter = svg_executor.generate_svg_pages(
                 design_spec,
@@ -506,6 +515,7 @@ async def run_pipeline(
                 enable_visual_critic=request.enable_visual_critic,
                 max_critic_attempts=request.max_critic_attempts,
                 visual_qa_max_attempts=request.visual_qa_max_attempts,
+                visual_critic_config=_visual_cfg,
                 template_context=template_context_exec or None,
                 template_skeletons=template_skeletons,
             )
@@ -529,6 +539,7 @@ async def run_pipeline(
                 enable_visual_critic=request.enable_visual_critic,
                 max_critic_attempts=request.max_critic_attempts,
                 visual_qa_max_attempts=request.visual_qa_max_attempts,
+                visual_critic_config=_visual_cfg,
                 template_context=template_context_exec or None,
                 template_skeletons=template_skeletons,
             )

--- a/backend/orchestrator/research_enrichment.py
+++ b/backend/orchestrator/research_enrichment.py
@@ -24,6 +24,7 @@ from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Any
 
 from backend.api.schemas import ResearchConfig
+from backend.config import get_tavily_api_key
 from backend.runtime import aoffload
 
 if TYPE_CHECKING:
@@ -298,7 +299,7 @@ async def _enrich_web_search(
         stats.web_error = "no_title"
         return
 
-    tavily_key = (config.tavily_api_key or "").strip()
+    tavily_key = get_tavily_api_key(config.tavily_api_key)
     serpapi_key = (config.serpapi_key or "").strip()
     provider = getattr(config, "web_search_provider", "tavily") or "tavily"
 


### PR DESCRIPTION
## Summary

- **Vision capability probe**: At startup, probes configured models for vision support using JPEG image test with color validation and retry logic
- **Auto-switch for visual QA**: When enabled and in agent mode, automatically switches to a vision-capable model during visual QA, then reverts back
- **Tavily global config**: Add Tavily API key as global .env setting with fallback chain (per-request > job config > global settings)
- **Environment documentation**: Document all new config options in .env.example

## Changes

| File | Change |
|:---|:---|
| `backend/llm/vision_probe.py` | New: vision capability probe with thread-safe cache, configurable retries, test helpers |
| `backend/generator/visual_critic.py` | Auto-switch gated behind `vision_auto_switch` flag, only effective in agent mode |
| `backend/app.py` | Startup probe + `/healthz/vision` endpoint with exception protection |
| `backend/config.py` | `get_tavily_api_key()`, `get_provider_credentials()`, `vision_auto_switch` setting |
| `backend/orchestrator/pipeline.py` | Pass `VisualCriticConfig` with agent-mode-aware auto-switch flag |
| `backend/api/endpoints/image_search.py` | Use shared Tavily key helper |
| `backend/orchestrator/image_search.py` | Use shared Tavily key helper |
| `backend/orchestrator/research_enrichment.py` | Use shared Tavily key helper |
| `.env.example` | Document TAVILY_API_KEY, OPENAI_BASE_URL, VISION_MODELS, VISION_MODEL, VISION_AUTO_SWITCH |

## Review fixes (round 2)

- **Race conditions**: Thread-safe cache with `threading.Lock`, snapshot in `get_vision_model()`
- **Test stability**: Configurable `max_retries`/`probe_timeout`, `reset()` and `wait_probed()` methods
- **Code quality**: Improved color validation with denial detection, frozenset constants, cleaned imports