### PR TITLE
[codex] Support SVG filters and gate Agent export

### DIFF
--- a/assets/agent_skills/paper-ppt-generate/SKILL.md
+++ b/assets/agent_skills/paper-ppt-generate/SKILL.md
@@ -99,7 +99,7 @@ preview.
 ## Quality Bar
 
 - Every SVG must parse as XML and define a correct canvas `viewBox`.
-- Do not use `<style>`, `class=`, `mask`, `filter`, `clipPath`, `foreignObject`, scripts, event handlers, or remote URLs in final SVGs.
+- Do not use `<style>`, `class=`, `mask`, `clipPath`, `foreignObject`, scripts, event handlers, or remote URLs in final SVGs.
 - Keep all needed assets local or embedded by relative path.
 - Avoid external image URLs in final SVGs.
 - Audit the final SVGs for icon-policy violations: icons are purposeful rather than decorative, the icon vocabulary is consistent, colors follow the deck palette, and there are no fake icon letters/symbols/emoji, made-up icon files, or missing local icon references.

--- a/assets/agent_skills/paper-ppt-generate/references/output-contract.md
+++ b/assets/agent_skills/paper-ppt-generate/references/output-contract.md
@@ -84,5 +84,5 @@ SVG requirements:
 - For Chinese text, avoid repeated short orphan lines and excessive blank space caused by overly narrow text boxes.
 - Every slide SVG must be directly authored as its own file. Multi-slide generator programs, loops, shared renderers, slide registries, and template expansion are forbidden.
 - Preserve source number precision and units; do not introduce K/M/B shorthand or rounded metrics unless the source uses them.
-- Do not include `<style>`, `class=`, masks, filters, clip paths, script tags, event handlers, remote network URLs, or `foreignObject`.
+- Do not include `<style>`, `class=`, masks, clip paths, script tags, event handlers, remote network URLs, or `foreignObject`.
 - Do not use text glyphs (letters, emoji, Unicode symbols, arrows, stars) as fake icons. Use existing local icon assets or omit the icon.

--- a/assets/agent_skills/paper-ppt-generate/references/slide-authoring.md
+++ b/assets/agent_skills/paper-ppt-generate/references/slide-authoring.md
@@ -41,7 +41,7 @@ Text:
 
 - Use normal SVG `<text>` elements.
 - Avoid excessive nested `tspan` complexity.
-- Do not use `foreignObject`, `<style>`, CSS classes, masks, filters, clip paths, scripts, event handlers, or remote URLs.
+- Do not use `foreignObject`, `<style>`, CSS classes, masks, clip paths, scripts, event handlers, or remote URLs.
 - Wrap against each text box's actual width and font size.
 - For Chinese body copy, let ordinary non-final lines use most of the available width, break at semantic boundaries, and allow light raggedness. Do not force a fixed characters-per-line target.
 - If wrapping is clearly wasteful or clips, widen or reallocate the text region, tune gaps, or adjust typography. Do not create huge blank bands with unnecessarily narrow text boxes.

--- a/assets/references/shared-standards.md
+++ b/assets/references/shared-standards.md
@@ -401,7 +401,7 @@ Best for: slides needing strong visual brand identity.
 | Text over image | Linear gradient overlay (direction matches text side) | Uniform flat opacity over whole image |
 | Cover / full-image slide | Bottom gradient bar + brand color | Solid black overlay |
 | Atmosphere / hero slide | Radial vignette | Unprocessed raw image |
-| Max PPT compatibility needed | Layered rect shadow | Filter-based shadow |
+| Max PPT compatibility needed | Filter shadow with native/fallback export verification | Unverified visual-only effects |
 
 ---
 

--- a/assets/templates/layouts/google_style/design_spec.md
+++ b/assets/templates/layouts/google_style/design_spec.md
@@ -242,9 +242,7 @@ The following SVG features are prohibited (not PPT-compatible):
 
 ### Shadow Implementation
 
-Since `filter` may affect PPT compatibility:
-- Use subtle border color variations to simulate shadows
-- Or accept that `filter` may be ignored in older PPT versions, though it works well in newer versions
+SVG `filter` effects may be used for shadows and glows. Verify final PPT output because supported shadows can export natively, while more complex filter graphs may use raster fallback.
 
 ---
 

--- a/assets/templates/layouts/pixel_retro/design_spec.md
+++ b/assets/templates/layouts/pixel_retro/design_spec.md
@@ -214,7 +214,7 @@ Apply glow filters to key text/elements:
 <text filter="url(#glowGreen)" fill="#39FF14">Glowing Text</text>
 ```
 
-> **Note**: `filter` effects are typically ignored in PPT, but render well in SVG-compatible viewers.
+> **Note**: `filter` effects should be verified in final PPT output; supported shadows can export natively, while complex glow effects may use raster fallback.
 
 ### Emoji Usage
 
@@ -250,7 +250,7 @@ Apply glow filters to key text/elements:
 - No `<g opacity="...">` (group opacity); set opacity on each child element individually
 - Use overlay layers instead of image opacity
 - Use inline styles only; external CSS and `@font-face` are prohibited
-- `filter` effects serve as enhancements (allowed) and do not affect baseline display
+- `filter` effects are allowed and should be verified in final PPT output
 
 ---
 

--- a/assets/templates/layouts/中汽研_商务/design_spec.md
+++ b/assets/templates/layouts/中汽研_商务/design_spec.md
@@ -134,7 +134,7 @@
 ### Mandatory Rules
 
 1. **Gradient Support**: Use `<linearGradient>` and `<radialGradient>` defined within `<defs>`.
-2. **Shadow Simulation**: PPT does not support SVG filter shadows. Use **semi-transparent black rectangles (`fill="#000000" fill-opacity="0.1"`)** with offset stacking to simulate card shadows.
+2. **Shadow Effects**: SVG filter shadows may be used. The export pipeline should preserve supported shadows natively or fall back to raster rendering for complex effects.
 3. **Opacity**: Strictly use `fill-opacity` / `stroke-opacity`.
 4. **Forbidden**: No `clipPath`, `mask`.
 

--- a/backend/api/endpoints/preview.py
+++ b/backend/api/endpoints/preview.py
@@ -229,7 +229,6 @@ async def save_pptist_preview_deck(job_id: str, payload: PptistDeckSaveRequest) 
 async def export_pptist_preview_deck(job_id: str, file: UploadFile = File(...)) -> dict[str, Any]:
     job = session_manager.get_job(job_id)
     project_dir = _preview_project_dir_for_id(job_id, job)
-    previous_output_path = job.output_path if job else None
     data = await file.read()
     if not data:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Exported PPTX is empty.")
@@ -255,12 +254,11 @@ async def export_pptist_preview_deck(job_id: str, file: UploadFile = File(...)) 
     except Exception as exc:  # pragma: no cover - invalid uploads or parser gaps should not block saving.
         scene_cache_ready = False
         render_info.setdefault("warnings", []).append(f"PPTist scene cache refresh skipped: {exc}")
-    download_ready = render_info.get("render_status") != "skipped" and scene_cache_ready
-    published_output_path = (
-        str(current_pptx)
-        if download_ready
-        else _stable_output_after_pptist_save(project_dir, previous_output_path, current_pptx)
-    )
+    # Download readiness is based on the PPTX package validation above. SVG
+    # refresh / scene cache failures should affect preview fallbacks only, not
+    # whether the user's saved PPTist edits can be downloaded.
+    download_ready = True
+    published_output_path = str(current_pptx)
     await _write_pptist_save_state(
         project_dir,
         {
@@ -995,21 +993,6 @@ def _find_latest_stable_output(project_dir: Path) -> Path | None:
         reverse=True,
     )
     return candidates[0] if candidates else None
-
-
-def _stable_output_after_pptist_save(
-    project_dir: Path,
-    previous_output_path: str | None,
-    current_pptx: Path,
-) -> str:
-    if previous_output_path:
-        previous = _resolve_workspace_file(previous_output_path)
-        if previous is not None and previous.exists() and previous != current_pptx:
-            return str(previous)
-    stable = _find_latest_stable_output(project_dir)
-    if stable is not None:
-        return str(stable)
-    return str(current_pptx)
 
 
 def _project_scene_paths(project_dir: Path):

--- a/backend/generator/svg_critic.py
+++ b/backend/generator/svg_critic.py
@@ -29,7 +29,7 @@ _TEXT_CLOSE_RE = re.compile(r"</text\s*>", re.IGNORECASE)
 
 # Elements explicitly forbidden by executor.md — mirrored here so the
 # critic fails fast instead of relying on LLM self-discipline.
-_FORBIDDEN_TAGS = {"mask", "style", "clipPath", "filter", "foreignObject"}
+_FORBIDDEN_TAGS = {"mask", "style", "clipPath", "foreignObject"}
 # `use` is allowed for icon references; `image` allowed for raster.
 
 

--- a/backend/generator/svg_to_pptx/converter.py
+++ b/backend/generator/svg_to_pptx/converter.py
@@ -22,6 +22,7 @@ from .elements import (
     convert_rect,
     convert_text,
 )
+from .styles import SvgEffectRequiresRasterFallback
 from .utils import parse_style_attribute, parse_transform, parse_transform_matrix
 
 # SVG elements that should be skipped
@@ -116,9 +117,11 @@ def _convert_element(elem: Any, ctx: ConvertContext) -> str:
 def _convert_g(elem: Any, ctx: ConvertContext) -> str:
     """Convert <g> group element with transform propagation."""
     transform_str = elem.get("transform", "")
+    style_overrides = parse_style_attribute(elem.get("style"))
+    if elem.get("filter") or style_overrides.get("filter"):
+        raise SvgEffectRequiresRasterFallback("Group-level SVG filters require raster fallback")
 
     # Extract inheritable styles
-    style_overrides = parse_style_attribute(elem.get("style"))
     for attr in [
         "fill",
         "stroke",

--- a/backend/generator/svg_to_pptx/elements.py
+++ b/backend/generator/svg_to_pptx/elements.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from .context import ConvertContext
 from .paths import normalize_path, parse_svg_path, path_commands_to_drawingml
-from .styles import build_fill_xml, build_stroke_xml
+from .styles import build_effect_xml, build_fill_xml, build_stroke_xml
 from .utils import (
     EMU_PER_PX,
     ANGLE_UNIT,
@@ -46,6 +46,7 @@ def _wrap_shape(
     geom_xml: str,
     fill_xml: str,
     stroke_xml: str,
+    effect_xml: str = "",
     rot: int = 0,
 ) -> str:
     """Wrap geometry into a standard <p:sp> shape element."""
@@ -62,6 +63,7 @@ def _wrap_shape(
         f'{geom_xml}'
         f'{fill_xml}'
         f'{stroke_xml}'
+        f'{effect_xml}'
         f'</p:spPr>'
         f'</p:sp>'
     )
@@ -87,10 +89,11 @@ def convert_rect(elem: Any, ctx: ConvertContext) -> str:
     opacity = _get_opacity(elem, ctx)
     fill = build_fill_xml(elem, ctx, opacity)
     stroke = build_stroke_xml(elem, ctx, opacity)
+    effect = build_effect_xml(elem, ctx)
 
     geom = '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
     sid = ctx.next_id()
-    return _wrap_shape(sid, f"Rect {sid}", off_x, off_y, ext_cx, ext_cy, geom, fill, stroke)
+    return _wrap_shape(sid, f"Rect {sid}", off_x, off_y, ext_cx, ext_cy, geom, fill, stroke, effect)
 
 
 def convert_circle(elem: Any, ctx: ConvertContext) -> str:
@@ -111,10 +114,11 @@ def convert_circle(elem: Any, ctx: ConvertContext) -> str:
     opacity = _get_opacity(elem, ctx)
     fill = build_fill_xml(elem, ctx, opacity)
     stroke = build_stroke_xml(elem, ctx, opacity)
+    effect = build_effect_xml(elem, ctx)
 
     geom = '<a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom>'
     sid = ctx.next_id()
-    return _wrap_shape(sid, f"Circle {sid}", off_x, off_y, ext_cx, ext_cy, geom, fill, stroke)
+    return _wrap_shape(sid, f"Circle {sid}", off_x, off_y, ext_cx, ext_cy, geom, fill, stroke, effect)
 
 
 def convert_ellipse(elem: Any, ctx: ConvertContext) -> str:
@@ -134,10 +138,11 @@ def convert_ellipse(elem: Any, ctx: ConvertContext) -> str:
     opacity = _get_opacity(elem, ctx)
     fill = build_fill_xml(elem, ctx, opacity)
     stroke = build_stroke_xml(elem, ctx, opacity)
+    effect = build_effect_xml(elem, ctx)
 
     geom = '<a:prstGeom prst="ellipse"><a:avLst/></a:prstGeom>'
     sid = ctx.next_id()
-    return _wrap_shape(sid, f"Ellipse {sid}", off_x, off_y, ext_cx, ext_cy, geom, fill, stroke)
+    return _wrap_shape(sid, f"Ellipse {sid}", off_x, off_y, ext_cx, ext_cy, geom, fill, stroke, effect)
 
 
 def convert_line(elem: Any, ctx: ConvertContext) -> str:
@@ -160,6 +165,7 @@ def convert_line(elem: Any, ctx: ConvertContext) -> str:
     opacity = _get_opacity(elem, ctx)
     fill = "<a:noFill/>"
     stroke = build_stroke_xml(elem, ctx, opacity)
+    effect = build_effect_xml(elem, ctx)
 
     geom = '<a:prstGeom prst="line"><a:avLst/></a:prstGeom>'
     sid = ctx.next_id()
@@ -181,6 +187,7 @@ def convert_line(elem: Any, ctx: ConvertContext) -> str:
         f'{geom}'
         f'{fill}'
         f'{stroke}'
+        f'{effect}'
         f'</p:spPr>'
         f'</p:sp>'
     )
@@ -206,10 +213,11 @@ def convert_path(elem: Any, ctx: ConvertContext) -> str:
     opacity = _get_opacity(elem, ctx)
     fill = build_fill_xml(elem, ctx, opacity)
     stroke = build_stroke_xml(elem, ctx, opacity)
+    effect = build_effect_xml(elem, ctx)
 
     geom = f'<a:custGeom><a:avLst/><a:gdLst/><a:ahLst/><a:cxnLst/><a:rect l="0" t="0" r="0" b="0"/><a:pathLst>{path_xml}</a:pathLst></a:custGeom>'
     sid = ctx.next_id()
-    return _wrap_shape(sid, f"Path {sid}", bx, by, bw, bh, geom, fill, stroke)
+    return _wrap_shape(sid, f"Path {sid}", bx, by, bw, bh, geom, fill, stroke, effect)
 
 
 def convert_polygon(elem: Any, ctx: ConvertContext) -> str:
@@ -238,6 +246,7 @@ def convert_text(elem: Any, ctx: ConvertContext) -> str:
     y = parse_svg_length(elem.get("y", 0))
     font_size_str = ctx.get_attr(elem, "font-size", "16")
     font_size = parse_svg_length(font_size_str, 16)
+    effect = build_effect_xml(elem, ctx)
 
     # PowerPoint does not reliably preserve positioned tspans, so split them
     # into independent text boxes when x/y/dx/dy is involved.
@@ -300,10 +309,10 @@ def convert_text(elem: Any, ctx: ConvertContext) -> str:
     if has_positioned_tspan:
         parts = []
         for segment in segments:
-            parts.append(_build_text_shape(segment["x"], segment["y"], segment["runs"], ctx, segment["anchor"]))
+            parts.append(_build_text_shape(segment["x"], segment["y"], segment["runs"], ctx, segment["anchor"], effect))
         return "".join(parts)
 
-    return _build_text_shape(x, y, [run for segment in segments for run in segment["runs"]], ctx, ctx.get_attr(elem, "text-anchor", "start"))
+    return _build_text_shape(x, y, [run for segment in segments for run in segment["runs"]], ctx, ctx.get_attr(elem, "text-anchor", "start"), effect)
 
 
 def convert_image(elem: Any, ctx: ConvertContext) -> str:
@@ -369,6 +378,7 @@ def convert_image(elem: Any, ctx: ConvertContext) -> str:
     off_y = px_to_emu(ctx.ctx_y(y))
     ext_cx = px_to_emu(ctx.ctx_w(w))
     ext_cy = px_to_emu(ctx.ctx_h(h))
+    effect = build_effect_xml(elem, ctx)
 
     sid = ctx.next_id()
     return (
@@ -384,6 +394,7 @@ def convert_image(elem: Any, ctx: ConvertContext) -> str:
         f'<a:xfrm><a:off x="{off_x}" y="{off_y}"/>'
         f'<a:ext cx="{ext_cx}" cy="{ext_cy}"/></a:xfrm>'
         f'<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
+        f'{effect}'
         f'</p:spPr>'
         f'</p:pic>'
     )
@@ -479,7 +490,7 @@ def _build_run_xml(run: dict) -> str:
     )
 
 
-def _build_text_shape(x: float, y: float, runs: list[dict], ctx: ConvertContext, anchor: str) -> str:
+def _build_text_shape(x: float, y: float, runs: list[dict], ctx: ConvertContext, anchor: str, effect_xml: str = "") -> str:
     """Build a single DrawingML text box."""
     total_text = "".join(run["text"] for run in runs)
     max_font_size = max((run["font_size"] for run in runs), default=16)
@@ -512,6 +523,7 @@ def _build_text_shape(x: float, y: float, runs: list[dict], ctx: ConvertContext,
         f'<a:ext cx="{ext_cx}" cy="{ext_cy}"/></a:xfrm>'
         f'<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>'
         f'<a:noFill/>'
+        f'{effect_xml}'
         f'</p:spPr>'
         f'<p:txBody>'
         f'<a:bodyPr wrap="none" anchor="t" lIns="0" tIns="0" rIns="0" bIns="0"><a:noAutofit/></a:bodyPr>'

--- a/backend/generator/svg_to_pptx/styles.py
+++ b/backend/generator/svg_to_pptx/styles.py
@@ -10,6 +10,7 @@ import re
 from typing import Any
 
 from .utils import (
+    ANGLE_UNIT,
     parse_hex_color,
     get_style_attr,
     parse_svg_length,
@@ -17,6 +18,10 @@ from .utils import (
     px_to_emu,
     resolve_url_id,
 )
+
+
+class SvgEffectRequiresRasterFallback(ValueError):
+    """Raised when an SVG effect should be preserved by raster fallback."""
 
 
 def build_fill_xml(elem: Any, ctx: Any, opacity: float = 1.0) -> str:
@@ -141,6 +146,49 @@ def build_stroke_xml(elem: Any, ctx: Any, opacity: float = 1.0) -> str:
     return f'<a:ln w="{width_emu}"{cap_attr}>{fill}{dash}{join_xml}</a:ln>'
 
 
+def build_effect_xml(elem: Any, ctx: Any) -> str:
+    """Build DrawingML effects from a supported SVG ``filter`` reference.
+
+    The native converter intentionally supports only the common presentation
+    shadow subset. More complex filter graphs should fall back to raster export
+    instead of silently dropping the visual effect.
+    """
+    filter_ref = ctx.get_attr(elem, "filter", "")
+    if not filter_ref or filter_ref == "none":
+        return ""
+
+    filter_id = resolve_url_id(filter_ref)
+    if not filter_id:
+        raise SvgEffectRequiresRasterFallback(f"SVG filter reference {filter_ref!r} requires raster fallback")
+
+    filter_elem = ctx.defs.get(filter_id)
+    if filter_elem is None:
+        raise SvgEffectRequiresRasterFallback(f"SVG filter #{filter_id} is not defined; raster fallback required")
+
+    shadow = _extract_shadow_filter(filter_elem)
+    if shadow is None:
+        raise SvgEffectRequiresRasterFallback(f"SVG filter #{filter_id} requires raster fallback")
+
+    dx = shadow["dx"] * _effect_scale_x(ctx)
+    dy = shadow["dy"] * _effect_scale_y(ctx)
+    std_dev = shadow["std_dev"] * _effect_scale_avg(ctx)
+    dist = px_to_emu(math.hypot(dx, dy))
+    blur = px_to_emu(std_dev * 2.0)
+    direction = round((math.degrees(math.atan2(dy, dx)) % 360.0) * ANGLE_UNIT) if dist else 0
+    alpha = round(shadow["opacity"] * 100000)
+
+    if dist <= 0 and blur <= 0:
+        return ""
+
+    return (
+        f'<a:effectLst>'
+        f'<a:outerShdw blurRad="{blur}" dist="{dist}" dir="{direction}" algn="tl" rotWithShape="0">'
+        f'<a:srgbClr val="{shadow["color"]}"><a:alpha val="{alpha}"/></a:srgbClr>'
+        f'</a:outerShdw>'
+        f'</a:effectLst>'
+    )
+
+
 def _build_dash_xml(dash_array: str) -> str:
     """Build dash pattern XML."""
     presets = {
@@ -167,3 +215,76 @@ def _build_dash_xml(dash_array: str) -> str:
 
 def _parse_opacity(val: str) -> float:
     return max(0.0, min(1.0, parse_svg_ratio(val, 1.0)))
+
+
+def _extract_shadow_filter(filter_elem: Any) -> dict[str, float | str] | None:
+    """Extract a simple drop-shadow-like SVG filter definition."""
+    dx = 0.0
+    dy = 0.0
+    std_dev = 0.0
+    color = "000000"
+    opacity = 1.0
+    saw_blur = False
+    saw_offset = False
+
+    for child in filter_elem:
+        tag = _local_name(child)
+        if tag == "feDropShadow":
+            std_dev = _parse_std_deviation(child.get("stdDeviation", "0"))
+            dx = parse_svg_length(child.get("dx", 0), 0.0)
+            dy = parse_svg_length(child.get("dy", 0), 0.0)
+            color = parse_hex_color(get_style_attr(child, "flood-color", "#000000")) or "000000"
+            opacity = _parse_opacity(get_style_attr(child, "flood-opacity", "1"))
+            return {
+                "dx": dx,
+                "dy": dy,
+                "std_dev": std_dev,
+                "color": color,
+                "opacity": opacity,
+            }
+        if tag == "feGaussianBlur":
+            std_dev = _parse_std_deviation(child.get("stdDeviation", "0"))
+            saw_blur = True
+        elif tag == "feOffset":
+            dx = parse_svg_length(child.get("dx", 0), 0.0)
+            dy = parse_svg_length(child.get("dy", 0), 0.0)
+            saw_offset = True
+        elif tag == "feFlood":
+            color = parse_hex_color(get_style_attr(child, "flood-color", "#000000")) or "000000"
+            opacity = _parse_opacity(get_style_attr(child, "flood-opacity", "1"))
+
+    if not saw_blur or not saw_offset:
+        return None
+
+    return {
+        "dx": dx,
+        "dy": dy,
+        "std_dev": std_dev,
+        "color": color,
+        "opacity": opacity,
+    }
+
+
+def _parse_std_deviation(value: object) -> float:
+    text = str(value or "0").replace(",", " ").strip()
+    parts = [parse_svg_length(part, 0.0) for part in text.split() if part.strip()]
+    if not parts:
+        return 0.0
+    return sum(parts[:2]) / min(len(parts), 2)
+
+
+def _local_name(elem: Any) -> str:
+    tag = getattr(elem, "tag", "")
+    return tag.split("}")[-1] if "}" in tag else tag
+
+
+def _effect_scale_x(ctx: Any) -> float:
+    return abs(getattr(ctx, "scale_x", 1.0)) or 1.0
+
+
+def _effect_scale_y(ctx: Any) -> float:
+    return abs(getattr(ctx, "scale_y", 1.0)) or 1.0
+
+
+def _effect_scale_avg(ctx: Any) -> float:
+    return (_effect_scale_x(ctx) + _effect_scale_y(ctx)) / 2.0

--- a/backend/orchestrator/agent_pipeline.py
+++ b/backend/orchestrator/agent_pipeline.py
@@ -73,6 +73,26 @@ class _ClaudeResponseOutcome:
     interrupted: bool = False
 
 
+@dataclass(frozen=True)
+class _AgentExportGateConfig:
+    canvas_format: str
+    total_slides_hint: int
+    export_prefix: str
+    max_attempts: int
+
+
+@dataclass
+class _AgentExportGateResult:
+    ok: bool
+    stage: str
+    message: str
+    output_path: str | None = None
+    stats: dict[str, Any] | None = None
+    attempt: int = 0
+    max_attempts: int = 0
+    exhausted: bool = False
+
+
 _RUNTIME_DEFAULT = "claude_code"
 _AGENT_SKILL_NAME = "paper-ppt-generate"
 _RESEARCH_SKILL_NAME = "paper-ppt-research"
@@ -80,6 +100,8 @@ _DEEP_RESEARCH_SKILL_NAME = "paper-ppt-deep-research"
 _SVG_SCAN_SECONDS = 1.0
 _AGENT_IDLE_NOTICE_SECONDS = 60.0
 _AGENT_INTERRUPT_POLL_SECONDS = 0.1
+_AGENT_EXPORT_GATE_STATE = "agent_export_gate.json"
+_AGENT_EXPORT_GATE_MAX_ATTEMPTS = 3
 _AGENT_IDLE_MESSAGE = (
     "Agent has not produced new activity for a while. "
     "You can pause it or send guidance to continue."
@@ -222,12 +244,14 @@ class PersistentAgentSession:
         *,
         resume_session_id: str | None = None,
         job_id: str = "",
+        export_gate: _AgentExportGateConfig | None = None,
     ) -> None:
         self._project_dir = project_dir
         self._runtime = runtime
         self._agent_config = agent_config
         self._resume_session_id = resume_session_id
         self._job_id = job_id
+        self._export_gate = export_gate
 
         # Cross-thread prompt injection (main thread -> worker thread).
         self._prompt_queue: queue.Queue[str | None] = queue.Queue()
@@ -255,6 +279,8 @@ class PersistentAgentSession:
 
     async def start(self, initial_prompt: str) -> None:
         """Launch the worker thread and send the first prompt."""
+        if self._export_gate is not None:
+            await aoffload(_clear_agent_export_gate_state, self._project_dir)
         self._caller_loop = asyncio.get_running_loop()
         self._worker_thread = threading.Thread(
             target=self._worker,
@@ -301,6 +327,10 @@ class PersistentAgentSession:
     def can_accept_feedback(self) -> bool:
         thread_alive = self._worker_thread is None or self._worker_thread.is_alive()
         return self._active and self._accepting_feedback and thread_alive
+
+    @property
+    def export_gate_enabled(self) -> bool:
+        return self._export_gate is not None
 
     @session_id.setter
     def session_id(self, value: str | None) -> None:
@@ -777,15 +807,22 @@ class PersistentAgentSession:
                     )
                 )
                 first_turn = True
+                pending_gate_prompt: str | None = None
+                export_gate_attempts = 0
                 while self._active:
-                    try:
-                        prompt = self._prompt_queue.get(timeout=1.0)
-                    except queue.Empty:
-                        continue
-                    if prompt is None:
-                        break
-                    if self._cancel_event.is_set():
-                        break
+                    prompt_kind = "export_gate" if pending_gate_prompt is not None else "user"
+                    if pending_gate_prompt is not None:
+                        prompt = pending_gate_prompt
+                        pending_gate_prompt = None
+                    else:
+                        try:
+                            prompt = self._prompt_queue.get(timeout=1.0)
+                        except queue.Empty:
+                            continue
+                        if prompt is None:
+                            break
+                        if self._cancel_event.is_set():
+                            break
                     # Start a new turn.
                     self._emit(
                         AgentProgressEvent(
@@ -796,7 +833,10 @@ class PersistentAgentSession:
                             data={"runtime": "codex", "thread_id": thread.id},
                         )
                     )
-                    turn_prompt = prompt if first_turn else _live_feedback_prompt(prompt)
+                    if first_turn or prompt_kind == "export_gate":
+                        turn_prompt = prompt
+                    else:
+                        turn_prompt = _live_feedback_prompt(prompt)
                     first_turn = False
                     turn = await thread.turn(
                         [SkillInput(name=_AGENT_SKILL_NAME, path=skill_path), TextInput(turn_prompt)],
@@ -859,8 +899,60 @@ class PersistentAgentSession:
                     if turn_interrupted:
                         self._accepting_feedback = True
                         continue
-                    # A finished Codex turn completes generation. Feedback sent
-                    # after export resumes this saved thread in a new run.
+                    if self._export_gate is not None:
+                        export_gate_attempts += 1
+                        self._emit(
+                            AgentProgressEvent(
+                                "export",
+                                "started",
+                                "Checking Agent output by exporting PPTX...",
+                                0.90,
+                                data={"runtime": "codex", "thread_id": thread.id},
+                            )
+                        )
+                        result = await _run_agent_export_gate(
+                            self._project_dir,
+                            canvas_format=self._export_gate.canvas_format,
+                            total_slides_hint=self._export_gate.total_slides_hint,
+                            export_prefix=self._export_gate.export_prefix,
+                            attempt=export_gate_attempts,
+                            max_attempts=self._export_gate.max_attempts,
+                        )
+                        if result.ok:
+                            self._emit(
+                                AgentProgressEvent(
+                                    "export",
+                                    "progress",
+                                    _agent_export_gate_success_message(result),
+                                    0.96,
+                                    data={
+                                        "runtime": "codex",
+                                        "thread_id": thread.id,
+                                        "output_path": result.output_path,
+                                    },
+                                )
+                            )
+                            self._active = False
+                            break
+                        self._emit(
+                            AgentProgressEvent(
+                                "agent",
+                                "progress",
+                                result.message,
+                                0.72,
+                                data={
+                                    "runtime": "codex",
+                                    "thread_id": thread.id,
+                                    "export_gate": "failed",
+                                    "attempt": export_gate_attempts,
+                                },
+                            )
+                        )
+                        if export_gate_attempts >= self._export_gate.max_attempts:
+                            raise RuntimeError(_agent_export_gate_exhausted_message(result))
+                        pending_gate_prompt = _agent_export_gate_followup_instruction(result)
+                        continue
+                    # Without an export gate, a finished Codex turn completes generation.
                     self._active = False
                     break
         except BaseException as exc:
@@ -917,7 +1009,10 @@ class PersistentAgentSession:
                 agent_config.get("_research_env"),
                 agent_config,
             ),
-            hooks=_agent_research_gate_hooks(self._project_dir),
+            hooks=_agent_research_gate_hooks(
+                self._project_dir,
+                export_gate=self._export_gate,
+            ),
             **session_opts,
         )
 
@@ -1114,6 +1209,248 @@ def _write_agent_contract_warnings(project_dir: Path, violations: list[str]) -> 
         )
     except OSError:
         logger.warning("Failed to persist Agent contract warnings for %s", project_dir)
+
+
+def _agent_export_gate_config(
+    *,
+    canvas_format: str,
+    total_slides_hint: int,
+    export_prefix: str,
+    agent_config: dict[str, Any],
+) -> _AgentExportGateConfig:
+    try:
+        max_attempts = int(agent_config.get("export_gate_max_attempts") or _AGENT_EXPORT_GATE_MAX_ATTEMPTS)
+    except (TypeError, ValueError):
+        max_attempts = _AGENT_EXPORT_GATE_MAX_ATTEMPTS
+    return _AgentExportGateConfig(
+        canvas_format=canvas_format,
+        total_slides_hint=max(0, int(total_slides_hint or 0)),
+        export_prefix=export_prefix,
+        max_attempts=max(1, max_attempts),
+    )
+
+
+def _agent_export_gate_path(project_dir: Path) -> Path:
+    return project_dir / _AGENT_EXPORT_GATE_STATE
+
+
+def _clear_agent_export_gate_state(project_dir: Path) -> None:
+    try:
+        _agent_export_gate_path(project_dir).unlink(missing_ok=True)
+    except OSError:
+        logger.warning("Failed to clear Agent export gate state for %s", project_dir)
+
+
+def _agent_export_gate_payload(result: _AgentExportGateResult) -> dict[str, Any]:
+    return {
+        "ok": result.ok,
+        "stage": result.stage,
+        "message": result.message,
+        "output_path": result.output_path,
+        "stats": result.stats or {},
+        "attempt": result.attempt,
+        "max_attempts": result.max_attempts,
+        "exhausted": result.exhausted,
+        "updated_at": datetime.now().isoformat(timespec="seconds"),
+    }
+
+
+async def _write_agent_export_gate_state(
+    project_dir: Path,
+    result: _AgentExportGateResult,
+) -> None:
+    await awrite_text(
+        _agent_export_gate_path(project_dir),
+        json.dumps(_agent_export_gate_payload(result), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _read_agent_export_gate_state(project_dir: Path) -> dict[str, Any]:
+    path = _agent_export_gate_path(project_dir)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _agent_export_gate_failure_result(
+    *,
+    stage: str,
+    exc: Exception,
+    attempt: int,
+    max_attempts: int,
+) -> _AgentExportGateResult:
+    detail = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+    if not detail:
+        detail = str(exc) or exc.__class__.__name__
+    return _AgentExportGateResult(
+        ok=False,
+        stage=stage,
+        message=f"Agent export gate failed during {stage}: {detail}",
+        attempt=attempt,
+        max_attempts=max_attempts,
+        exhausted=attempt >= max_attempts,
+    )
+
+
+async def _run_agent_export_gate(
+    project_dir: Path,
+    *,
+    canvas_format: str,
+    total_slides_hint: int,
+    export_prefix: str,
+    attempt: int,
+    max_attempts: int,
+) -> _AgentExportGateResult:
+    try:
+        svg_files = await aoffload(lambda: get_svg_files(project_dir, source="output"))
+        await aoffload(_validate_agent_artifacts, project_dir, svg_files, total_slides_hint)
+    except Exception as exc:  # noqa: BLE001 - return deterministic failure to Agent
+        result = _agent_export_gate_failure_result(
+            stage="validation",
+            exc=exc,
+            attempt=attempt,
+            max_attempts=max_attempts,
+        )
+        await _write_agent_export_gate_state(project_dir, result)
+        return result
+
+    try:
+        async with heavy_stage_slot():
+            stats = await aoffload(finalize_project, project_dir)
+    except Exception as exc:  # noqa: BLE001 - return deterministic failure to Agent
+        result = _agent_export_gate_failure_result(
+            stage="finalize",
+            exc=exc,
+            attempt=attempt,
+            max_attempts=max_attempts,
+        )
+        await _write_agent_export_gate_state(project_dir, result)
+        return result
+
+    try:
+        final_svg_files = await aoffload(lambda: get_svg_files(project_dir, source="final"))
+        if not final_svg_files:
+            raise RuntimeError("No finalized SVG files were produced.")
+        notes = await aoffload(get_notes, project_dir, final_svg_files)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+        pptx_path = project_dir / "exports" / f"{export_prefix}_{timestamp}.pptx"
+        await aoffload(pptx_path.parent.mkdir, parents=True, exist_ok=True)
+        async with heavy_stage_slot():
+            await aoffload(
+                create_pptx,
+                final_svg_files,
+                pptx_path,
+                canvas_format=canvas_format,
+                notes=notes,
+            )
+        if not pptx_path.exists() or pptx_path.stat().st_size <= 0:
+            raise RuntimeError(f"PPTX export did not create a non-empty file: {pptx_path}")
+    except Exception as exc:  # noqa: BLE001 - return deterministic failure to Agent
+        result = _agent_export_gate_failure_result(
+            stage="export",
+            exc=exc,
+            attempt=attempt,
+            max_attempts=max_attempts,
+        )
+        await _write_agent_export_gate_state(project_dir, result)
+        return result
+
+    result = _AgentExportGateResult(
+        ok=True,
+        stage="export",
+        message=f"Agent export gate passed: {pptx_path}",
+        output_path=str(pptx_path),
+        stats=stats if isinstance(stats, dict) else {},
+        attempt=attempt,
+        max_attempts=max_attempts,
+        exhausted=False,
+    )
+    await _write_agent_export_gate_state(project_dir, result)
+    return result
+
+
+def _agent_export_gate_success_message(result: _AgentExportGateResult) -> str:
+    return f"Agent export gate passed; PPTX exported successfully: {result.output_path}"
+
+
+def _agent_export_gate_exhausted_message(result: _AgentExportGateResult) -> str:
+    attempts = f"{result.attempt}/{result.max_attempts}" if result.max_attempts else str(result.attempt)
+    return f"Agent export gate failed after {attempts} attempt(s). {result.message}"
+
+
+def _agent_export_gate_followup_instruction(result: _AgentExportGateResult) -> str:
+    attempts = f"{result.attempt}/{result.max_attempts}" if result.max_attempts else str(result.attempt)
+    return f"""The backend ran the real PPTX export gate before allowing Agent mode to finish, and it failed.
+
+Attempt: {attempts}
+Stage: {result.stage}
+Failure:
+{result.message}
+
+Do not stop yet. Fix the source artifacts in this workspace, especially files under
+`svg_output/` and `agent_report.json` if needed. Validate raw SVG XML, not only
+browser preview. Then finish again so the export gate can re-run. Common XML text
+fixes include escaping literal `<` as `&lt;` and bare `&` as `&amp;`.
+"""
+
+
+def _agent_export_gate_completion_events(
+    project_dir: Path,
+    *,
+    total_slides_hint: int,
+    generation_message: str,
+    postprocess_message: str,
+    export_message: str,
+) -> list[AgentProgressEvent] | None:
+    state = _read_agent_export_gate_state(project_dir)
+    if not state.get("ok"):
+        return None
+    output_path = str(state.get("output_path") or "")
+    if not output_path or not Path(output_path).exists():
+        raise RuntimeError(
+            f"Agent export gate reported success, but PPTX is missing: {output_path or '<empty>'}"
+        )
+    svg_files = get_svg_files(project_dir, source="output")
+    count = len(svg_files)
+    if total_slides_hint and count < total_slides_hint:
+        raise RuntimeError(
+            f"Agent export gate reported success with {count} slides, expected at least {total_slides_hint}."
+        )
+    stats = state.get("stats") if isinstance(state.get("stats"), dict) else {}
+    processed = int(stats.get("total_files") or count)
+    return [
+        AgentProgressEvent(
+            "generation",
+            "complete",
+            generation_message.format(count=count),
+            0.75,
+            data={"total_slides": count, "generation_mode": "agent"},
+        ),
+        AgentProgressEvent(
+            "postprocess",
+            "complete",
+            postprocess_message.format(count=processed),
+            0.88,
+        ),
+        AgentProgressEvent(
+            "export",
+            "complete",
+            export_message,
+            1.0,
+            data={"output_path": output_path},
+        ),
+    ]
+
+
+def _agent_export_gate_missing_message(project_dir: Path) -> str:
+    state = _read_agent_export_gate_state(project_dir)
+    message = str(state.get("message") or "").strip()
+    if message:
+        return message
+    return "Agent export gate did not produce a successful PPTX export result."
 
 
 def _agent_generation_contract_violations(
@@ -1351,6 +1688,12 @@ async def run_agent_pipeline(request: Any):
         agent_config,
         resume_session_id=resume_session_id,
         job_id=job_id,
+        export_gate=_agent_export_gate_config(
+            canvas_format=str(request.canvas_format),
+            total_slides_hint=total_slides_hint,
+            export_prefix="presentation_agent",
+            agent_config=agent_config,
+        ),
     )
     if job_id:
         from backend.orchestrator.agent_session_registry import register as registry_register
@@ -1442,15 +1785,6 @@ async def run_agent_pipeline(request: Any):
     try:
         await drainer_task
 
-        # Session is now in direct mode — feedback turns broadcast via
-        # session_manager.record_event directly.  Proceed to finalization.
-        async for repair_event in _repair_agent_generation_contracts_if_needed(
-            project_dir,
-            runtime,
-            agent_config,
-        ):
-            yield repair_event
-
         await _scan_svg_updates(
             project_dir,
             queue,
@@ -1460,6 +1794,29 @@ async def run_agent_pipeline(request: Any):
         )
         while not queue.empty():
             yield queue.get_nowait()
+
+        if session.export_gate_enabled:
+            gate_events = _agent_export_gate_completion_events(
+                project_dir,
+                total_slides_hint=total_slides_hint,
+                generation_message="Agent generated {count} slides.",
+                postprocess_message="Processed {count} files",
+                export_message="PowerPoint generated!",
+            )
+            if gate_events is None:
+                raise RuntimeError(_agent_export_gate_missing_message(project_dir))
+            for event in gate_events:
+                yield event
+            return
+
+        # Session is now in direct mode — feedback turns broadcast via
+        # session_manager.record_event directly.  Proceed to finalization.
+        async for repair_event in _repair_agent_generation_contracts_if_needed(
+            project_dir,
+            runtime,
+            agent_config,
+        ):
+            yield repair_event
 
         svg_files = get_svg_files(project_dir, source="output")
         _validate_agent_artifacts(project_dir, svg_files, total_slides_hint)
@@ -1562,6 +1919,13 @@ async def run_agent_feedback_pipeline(
         runtime,
         agent_config,
         resume_session_id=effective_session_id,
+        job_id=job_id,
+        export_gate=_agent_export_gate_config(
+            canvas_format=_canvas_format_from_task(project_dir),
+            total_slides_hint=total_hint,
+            export_prefix="presentation_agent_feedback",
+            agent_config=agent_config,
+        ),
     )
     if job_id:
         from backend.orchestrator.agent_session_registry import register as registry_register
@@ -1650,6 +2014,20 @@ async def run_agent_feedback_pipeline(
     )
     while not queue.empty():
         yield queue.get_nowait()
+
+    if session.export_gate_enabled:
+        gate_events = _agent_export_gate_completion_events(
+            project_dir,
+            total_slides_hint=total_hint,
+            generation_message="Agent updated {count} slides.",
+            postprocess_message="Processed {count} files",
+            export_message="Updated PowerPoint generated!",
+        )
+        if gate_events is None:
+            raise RuntimeError(_agent_export_gate_missing_message(project_dir))
+        for event in gate_events:
+            yield event
+        return
 
     async for repair_event in _repair_agent_generation_contracts_if_needed(
         project_dir,
@@ -2699,7 +3077,10 @@ def _validate_agent_artifacts(project_dir: Path, svg_files: list[Path], total_sl
             f"Agent produced {len(svg_files)} slides, expected at least {total_slides_hint}."
         )
     for svg_path in svg_files:
-        _validate_single_svg(svg_path, svg_path.read_text(encoding="utf-8"))
+        try:
+            _validate_single_svg(svg_path, svg_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise RuntimeError(f"{svg_path.name}: SVG validation failed: {exc}") from exc
     report_path = _require_agent_report(project_dir)
     authorship_violations = _agent_slide_authorship_violations(
         project_dir,
@@ -3155,8 +3536,14 @@ def _agent_batch_authoring_block_reason(
     return None
 
 
-def _agent_research_gate_hooks(project_dir: Path) -> dict[str, list[Any]]:
+def _agent_research_gate_hooks(
+    project_dir: Path,
+    *,
+    export_gate: _AgentExportGateConfig | None = None,
+) -> dict[str, list[Any]]:
     from claude_agent_sdk import HookMatcher
+
+    export_gate_attempts = 0
 
     async def _enforce_agent_authoring_contracts(
         input_data: dict[str, Any],
@@ -3181,7 +3568,7 @@ def _agent_research_gate_hooks(project_dir: Path) -> dict[str, list[Any]]:
             }
         }
 
-    return {
+    hooks: dict[str, list[Any]] = {
         "PreToolUse": [
             HookMatcher(
                 matcher="Write|Edit|MultiEdit|NotebookEdit|Bash",
@@ -3189,6 +3576,42 @@ def _agent_research_gate_hooks(project_dir: Path) -> dict[str, list[Any]]:
             )
         ]
     }
+
+    if export_gate is not None:
+
+        async def _enforce_agent_export_gate(
+            _input_data: dict[str, Any],
+            _tool_use_id: str | None,
+            _context: Any,
+        ) -> dict[str, Any]:
+            nonlocal export_gate_attempts
+            export_gate_attempts += 1
+            result = await _run_agent_export_gate(
+                project_dir,
+                canvas_format=export_gate.canvas_format,
+                total_slides_hint=export_gate.total_slides_hint,
+                export_prefix=export_gate.export_prefix,
+                attempt=export_gate_attempts,
+                max_attempts=export_gate.max_attempts,
+            )
+            if result.ok:
+                return {
+                    "systemMessage": _agent_export_gate_success_message(result),
+                }
+            if export_gate_attempts >= export_gate.max_attempts:
+                return {
+                    "continue": False,
+                    "stopReason": _agent_export_gate_exhausted_message(result),
+                    "systemMessage": _agent_export_gate_exhausted_message(result),
+                }
+            return {
+                "decision": "block",
+                "reason": _agent_export_gate_followup_instruction(result),
+            }
+
+        hooks["Stop"] = [HookMatcher(hooks=[_enforce_agent_export_gate])]
+
+    return hooks
 
 
 def _validate_agent_report(project_dir: Path, report_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add native SVG filter handling for PPTX export, including shadow/filter style parsing and preservation in the converter path.
- Remove remaining Agent/template guidance that treated SVG filters as prohibited so generated decks can exercise filter support.
- Add an Agent export gate: Agent mode now must pass deterministic raw SVG validation, finalization, and real PPTX export before the job is marked complete.

## Why

Browser/editor previews can mask malformed raw SVG by rendering repaired or recovered content. A deck can therefore look acceptable in preview while failing during final PPTX export. The export result now acts as the completion gate so Agent mode keeps working when export fails instead of stopping first and failing afterward.

## Validation

- `uv run python -m py_compile backend\orchestrator\agent_pipeline.py backend\generator\svg_to_pptx\converter.py backend\generator\svg_to_pptx\elements.py backend\generator\svg_to_pptx\styles.py backend\generator\svg_critic.py backend\api\endpoints\preview.py`
- `$env:PYTHONPATH='.'; uv run --extra dev python -m pytest tests\test_agent_preview_resilience.py::test_agent_artifact_validation_reports_malformed_svg_filename tests\test_agent_preview_resilience.py::test_agent_export_gate_success_writes_completion_state tests\test_agent_runtime_lifecycle.py tests\test_svg_to_pptx_filters.py -q`
- Manually verified the failing workspace reports `slide_026.svg: SVG validation failed: not well-formed (invalid token): line 26, column 119` through the export gate.
