### PR TITLE
Merge dev into master: pin Node.js installer to v22 LTS

### DIFF
--- a/scripts/start-launcher.ps1
+++ b/scripts/start-launcher.ps1
@@ -277,8 +277,10 @@ function Install-Node {
   Write-Host ""
   if (Test-Cmd "winget") {
     try {
-      # No --silent: let winget print its download/install progress.
-      & winget install --id OpenJS.NodeJS.LTS -e --accept-source-agreements --accept-package-agreements
+      # Pin to Node.js 22 LTS (the "LTS" winget id currently points at v24,
+      # which ships npm 11 with known module-load regressions). v22 is the
+      # verified, stable long-term-support line.
+      & winget install --id OpenJS.NodeJS.22 -e --accept-source-agreements --accept-package-agreements
       if ($LASTEXITCODE -eq 0) {
         Update-EnvPath
         Write-Host ""
@@ -295,7 +297,7 @@ function Install-Node {
   Write-Host ""
   Write-Warn2 (L nodeManualGuide)
   Write-Host  "  - https://nodejs.org/" -ForegroundColor Cyan
-  Write-Host  "  - winget install OpenJS.NodeJS.LTS" -ForegroundColor Cyan
+  Write-Host  "  - winget install OpenJS.NodeJS.22" -ForegroundColor Cyan
   Write-Host  (L nodeManualHint)
   return $false
 }

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -172,13 +172,22 @@ install_uv() {
 install_node() {
   step "$(l installingNode)"
   echo ""
+  # Pin to Node.js 22 LTS (the "LTS" channel has moved to v24 on some
+  # package managers, which ships npm 11 with known module-load issues).
   if has_cmd brew; then
-    if brew install node; then refresh_path; echo ""; ok "$(l nodeBrewOk)"; return; fi
+    if brew install node@22; then
+      # node@22 is keg-only; link it so it lands on PATH.
+      brew link --force --overwrite node@22 2>/dev/null || true
+      refresh_path
+      echo ""
+      ok "$(l nodeBrewOk)"
+      return
+    fi
     warn "$(l nodeBrewFail)"
   fi
   if has_cmd apt-get; then
     warn "$(l nodeAptHint)"
-    echo "${CYAN}  curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs${RESET}"
+    echo "${CYAN}  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash - && sudo apt-get install -y nodejs${RESET}"
     echo "${CYAN}  or: https://nodejs.org/en/download/package-manager${RESET}"
     echo "$(l nodeRetry)"
     return


### PR DESCRIPTION
Sync master with dev. Includes the launcher fix that pins the Node.js installer to the v22 LTS line (avoiding npm 11 crashes on v24).